### PR TITLE
`LocalPath`, `AbsolutePath`: add constructor conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#26: Publish PDB files to NuGet](https://github.com/ForNeVeR/TruePath/issues/26) (in form of `.snupkg` for now).
 - Update and publish XML documentation with the package.
 - Enable the Source Link.
+- [#29](https://github.com/ForNeVeR/TruePath/issues/29): add converting constructors for `LocalPath` and `AbsolutePath`.
 
 ## [1.0.0] - 2024-04-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ var alsoBazSubdirectory = myRoot / new LocalPath("baz");
 ### `AbsolutePath`
 This functions basically the same as the `LocalPath`, but it is _always_ an absolute path, which is checked in the constructor.
 
+To convert from `LocalPath` to `AbsolutePath` and vice versa, you can use the constructors of `AbsolutePath` and `LocalPath` respectively. Any `AbsolutePath` constructor (from either a string or a `LocalPath`) has same check for absolute path, and any `LocalPath` constructor (from either a string or an `AbsolutePath`) doesn't have any checks.
+
 ### `LocalPathPattern`
 This is a marker type that doesn't offer any advanced functionality over the contained string. It is used to mark paths that include wildcards, for further integration with external libraries, such as [Microsoft.Extensions.FileSystemGlobbing][file-system-globbing.nuget].
 

--- a/TruePath.Tests/AbsolutePathTests.cs
+++ b/TruePath.Tests/AbsolutePathTests.cs
@@ -11,7 +11,7 @@ public class AbsolutePathTests
     {
         if (!OperatingSystem.IsWindows()) return;
 
-        var path = @"C:/Users/John Doe\Documents";
+        const string path = @"C:/Users/John Doe\Documents";
         var absolutePath = new AbsolutePath(path);
         Assert.Equal(@"C:\Users\John Doe\Documents", absolutePath.Value);
     }
@@ -19,8 +19,13 @@ public class AbsolutePathTests
     [Fact]
     public void ConstructorThrowsOnNonRootedPath()
     {
-        var path = "uprooted";
+        const string path = "uprooted";
+        const string expectedMessage = $"Path \"{path}\" is not absolute.";
         var ex = Assert.Throws<ArgumentException>(() => new AbsolutePath(path));
-        Assert.Equal("""Path "uprooted" is not absolute.""", ex.Message);
+        Assert.Equal(expectedMessage, ex.Message);
+
+        var localPath = new LocalPath("uprooted");
+        ex = Assert.Throws<ArgumentException>(() => new AbsolutePath(localPath));
+        Assert.Equal(expectedMessage, ex.Message);
     }
 }

--- a/TruePath.Tests/LocalPathTests.cs
+++ b/TruePath.Tests/LocalPathTests.cs
@@ -11,7 +11,7 @@ public class LocalPathTests
     {
         if (!OperatingSystem.IsWindows()) return;
 
-        var path = @"C:/Users/John Doe\Documents";
+        const string path = @"C:/Users/John Doe\Documents";
         var absolutePath = new LocalPath(path);
         Assert.Equal(@"C:\Users\John Doe\Documents", absolutePath.Value);
     }
@@ -32,8 +32,18 @@ public class LocalPathTests
     {
         if (!OperatingSystem.IsWindows()) return;
 
-        var path = @"Users/John Doe\Documents";
+        const string path = @"Users/John Doe\Documents";
         var relativePath = new LocalPath(path);
         Assert.Equal(@"Users\John Doe\Documents", relativePath.Value);
+    }
+
+    [Fact]
+    public void LocalPathConvertedFromAbsolute()
+    {
+        var absolutePath = new AbsolutePath("/foo/bar");
+        LocalPath localPath1 = absolutePath;
+        var localPath2 = new LocalPath(absolutePath);
+
+        Assert.Equal(localPath1, localPath2);
     }
 }

--- a/TruePath/AbsolutePath.cs
+++ b/TruePath/AbsolutePath.cs
@@ -11,7 +11,7 @@ namespace TruePath;
 /// <remarks>For a path that's not guaranteed to be absolute, use the <see cref="LocalPath"/> type.</remarks>
 public readonly struct AbsolutePath
 {
-    private readonly LocalPath _underlying;
+    internal readonly LocalPath Underlying;
     /// <summary>
     /// Creates an <see cref="AbsolutePath"/> instance by normalizing the path from the passed string according to the
     /// rules stated in <see cref="LocalPath"/>.
@@ -20,20 +20,26 @@ public readonly struct AbsolutePath
     /// <exception cref="ArgumentException">Thrown if the passed string does not represent an absolute path.</exception>
     public AbsolutePath(string value)
     {
-        _underlying = new LocalPath(value);
-        if (!_underlying.IsAbsolute)
+        Underlying = new LocalPath(value);
+        if (!Underlying.IsAbsolute)
             throw new ArgumentException($"Path \"{value}\" is not absolute.");
     }
 
+    /// <summary>
+    /// Creates an <see cref="AbsolutePath"/> instance by converting a <paramref name="localPath"/> object.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown if the passed path is not absolute.</exception>
+    public AbsolutePath(LocalPath localPath) : this(localPath.Value) {}
+
     /// <summary>The normalized path string.</summary>
-    public string Value => _underlying.Value;
+    public string Value => Underlying.Value;
 
     /// <summary>The parent of this path. Will be <c>null</c> for a rooted absolute path.</summary>
-    public AbsolutePath? Parent => _underlying.Parent is { } path ? new(path.Value) : null;
+    public AbsolutePath? Parent => Underlying.Parent is { } path ? new(path.Value) : null;
         // TODO[#17]: Optimize, the strict check here is not necessary.
 
     /// <summary>The full name of the last component of this path.</summary>
-    public string FileName => _underlying.FileName;
+    public string FileName => Underlying.FileName;
 
     /// <remarks>
     /// Note that in case path <paramref name="b"/> is <b>absolute</b>, it will completely take over and the
@@ -55,7 +61,7 @@ public readonly struct AbsolutePath
     /// <remarks>Note that currently this comparison is case-sensitive.</remarks>
     public bool Equals(AbsolutePath other)
     {
-        return _underlying.Equals(other._underlying);
+        return Underlying.Equals(other.Underlying);
     }
 
     /// <inheritdoc cref="Equals(AbsolutePath)"/>
@@ -67,7 +73,7 @@ public readonly struct AbsolutePath
     /// <inheritdoc cref="Object.GetHashCode"/>
     public override int GetHashCode()
     {
-        return _underlying.GetHashCode();
+        return Underlying.GetHashCode();
     }
 
     /// <inheritdoc cref="Equals(AbsolutePath)"/>

--- a/TruePath/LocalPath.cs
+++ b/TruePath/LocalPath.cs
@@ -21,7 +21,7 @@ public readonly struct LocalPath(string value)
     /// <para>Checks whether th path is absolute.</para>
     /// <para>
     ///     Currently, any rooted paths are considered absolute, but this is a subject to change: on Windows, there
-    ///     will be an additional requirement for a path to be either UNC or start from a disk letter.
+    ///     will be an additional requirement for a path to be either a DOS device path or start from a disk letter.
     /// </para>
     /// </summary>
     public bool IsAbsolute => Path.IsPathRooted(Value);
@@ -86,6 +86,7 @@ public readonly struct LocalPath(string value)
     /// <returns>The relative path from the base path to this path.</returns>
     public LocalPath RelativeTo(LocalPath basePath) => new(Path.GetRelativePath(basePath.Value, Value));
 
+    // ReSharper disable once GrammarMistakeInComment // RIDER-111735
     /// <remarks>
     /// Note that in case path <paramref name="b"/> is <b>absolute</b>, it will completely take over and the
     /// <paramref name="basePath"/> will be ignored.
@@ -93,6 +94,7 @@ public readonly struct LocalPath(string value)
     public static LocalPath operator /(LocalPath basePath, LocalPath b) =>
         new(Path.Combine(basePath.Value, b.Value));
 
+    // ReSharper disable once GrammarMistakeInComment // RIDER-111735
     /// <remarks>
     /// Note that in case path <paramref name="b"/> is <b>absolute</b>, it will completely take over and the
     /// <paramref name="basePath"/> will be ignored.
@@ -100,8 +102,14 @@ public readonly struct LocalPath(string value)
     public static LocalPath operator /(LocalPath basePath, string b) => basePath / new LocalPath(b);
 
     /// <summary>
-    /// Implicitly converts a string to a <see cref="LocalPath"/>.
+    /// Implicitly converts an <see cref="AbsolutePath"/> to a <see cref="LocalPath"/>.
     /// </summary>
     /// <remarks>Note that this conversion doesn't lose any information.</remarks>
-    public static implicit operator LocalPath(AbsolutePath path) => new(path.Value);
+    public static implicit operator LocalPath(AbsolutePath path) => path.Underlying;
+
+    // ReSharper disable once GrammarMistakeInComment // RIDER-111735
+    /// <summary>Converts an <see cref="AbsolutePath"/> to a <see cref="LocalPath"/>.</summary>
+    public LocalPath(AbsolutePath path) : this(path.Value)
+    {
+    }
 }


### PR DESCRIPTION
Closes #29.