### PR TITLE
TruePath: optimize path normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - New `IPath` and `IPath<TPath>` interfaces that allow to process any paths (`LocalPath` and `AbsolutePath`) in a polymorphic way.
 
+### Changed
+- [#19](https://github.com/ForNeVeR/TruePath/issues/19): Optimize `PathStrings.Normalize` method.
+
+  Thanks ot @BadRyuner.
+
 ## [1.1.0] - 2024-04-27
 ### Added
 - [#26: Publish PDB files to NuGet](https://github.com/ForNeVeR/TruePath/issues/26) (in form of `.snupkg` for now).

--- a/TruePath.Benchmarks/PathStrings.cs
+++ b/TruePath.Benchmarks/PathStrings.cs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+//
+// SPDX-License-Identifier: MIT
+
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace TruePath;
+
+/// <summary>Helper methods to manipulate paths as strings.</summary>
+public static class PathStrings
+{
+    public static string Normalize1(string path)
+    {
+        // TODO[#19]: Optimize this. It is possible to do with less allocations.
+        var segments = new List<(int Start, int End)>();
+
+        int? currentSegmentStart = 0;
+        for (var i = 0; i < path.Length; i++)
+        {
+            if (path[i] == Path.DirectorySeparatorChar || path[i] == Path.AltDirectorySeparatorChar)
+            {
+                if (currentSegmentStart is { } s)
+                {
+                    segments.Add((s, i));
+                    currentSegmentStart = null;
+                }
+            }
+            else
+            {
+                currentSegmentStart ??= i;
+            }
+        }
+
+        if (currentSegmentStart is { } start)
+            segments.Add((start, path.Length));
+
+        var resultSegments = new LinkedList<(int Start, int End)>();
+        foreach (var segment in segments)
+        {
+            var text = path.AsSpan()[segment.Start..segment.End];
+            switch (text)
+            {
+                case ".":
+                    continue;
+                case ".." when resultSegments.Count > 0
+                               // check for the root segment (empty)
+                               && resultSegments.Last!.Value.Start != resultSegments.Last.Value.End:
+                    resultSegments.RemoveLast();
+                    break;
+                default:
+                    resultSegments.AddLast(segment);
+                    break;
+            }
+        }
+
+        var buffer = new StringBuilder();
+        var index = 0;
+        foreach (var segment in resultSegments)
+        {
+            buffer.Append(path, segment.Start, segment.End - segment.Start);
+            if (++index < resultSegments.Count
+                // check for the root segment: in such case, we still want to add the separator
+                || segment.Start == segment.End)
+                buffer.Append(Path.DirectorySeparatorChar);
+        }
+
+        return buffer.ToString();
+    }
+
+    /// <summary>
+    /// <para>
+    ///     Will convert a path string to a normalized path, using path separator specific for the current system.
+    /// </para>
+    /// <para>
+    ///     The normalization includes:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             converting all the <see cref="Path.AltDirectorySeparatorChar"/> to
+    ///             <see cref="Path.DirectorySeparatorChar"/> (e.g. <c>/</c> to <c>\</c> on Windows),
+    ///         </item>
+    ///         <item>
+    ///             collapsing any repeated separators in the input to only one separator (e.g. <c>//</c> to just
+    ///             <c>/</c> on Unix),
+    ///         </item>
+    ///         <item>
+    ///             resolving any sequence of current and parent directory marks (subsequently, <c>.</c> and <c>..</c>)
+    ///             if possible (meaning they will not be replaced if they are in the root position: paths such as
+    ///             <c>.</c> or <c>../..</c> will not be affected by the normalization, while e.g. <c>foo/../.</c> will
+    ///             be resolved to just <c>foo</c>).
+    ///         </item>
+    ///     </list>
+    /// </para>
+    /// <para>
+    ///     Note that this operation will never perform any file IO, and is purely string manipulation.
+    /// </para>
+    /// </summary>
+    [SkipLocalsInit] // is necessary to prevent the CLR from filling stackalloc with zeros.
+    public static string Normalize2(string path)
+    {
+        int written = 0;
+
+        char[]? array = path.Length < (IntPtr.Size == 4 ? 512 : 4096) ? null : ArrayPool<char>.Shared.Rent(path.Length);
+
+        Span<char> normalized = array != null ? array.AsSpan() : stackalloc char[path.Length];
+        ReadOnlySpan<char> source = path.AsSpan();
+
+        var buffer = normalized;
+
+        while (true)
+        {
+            bool last = false;
+            var separator = source.IndexOf(Path.DirectorySeparatorChar);
+            var altSeparator = source.IndexOf(Path.AltDirectorySeparatorChar);
+
+            if (altSeparator == -1 && separator == -1) { last = true; separator = source.Length - 1; }
+            else if (separator == -1) separator = altSeparator;
+            else if (altSeparator == -1) { }
+            else separator = Math.Min(separator, altSeparator);
+
+            separator++;
+            var block = source.Slice(0, separator);
+
+            bool skip;
+            // skip if '.'
+            if (block.Length == 1 && block[0] == '.')
+                skip = true;
+            // skip if './'
+            else if (block.Length == 2 && block[0] == '.' && (block[1] == Path.DirectorySeparatorChar || block[1] == Path.AltDirectorySeparatorChar))
+                skip = true;
+            // cut if '..' or '../'
+            else if (written != 0 && block.Length is 2 or 3 && block.StartsWith(".."))
+            {
+                var jump = normalized.Slice(0, written - 1).LastIndexOf(Path.DirectorySeparatorChar);
+
+                if (jump == -1 && written > 1)
+                {
+                    written = 0;
+                    buffer = normalized;
+                    skip = true;
+                }
+                else if (jump != -1)
+                {
+                    written = jump;
+                    buffer = normalized.Slice(written + 1);
+                    skip = true;
+                }
+                else
+                    skip = false;
+            }
+            else
+                skip = false;
+
+            // append sliced path
+            if (!skip)
+            {
+                block.CopyTo(buffer);
+                written += separator;
+                // replace \ with / if ends with \
+                if (separator > 0 && buffer[separator - 1] == Path.AltDirectorySeparatorChar)
+                    buffer[separator - 1] = Path.DirectorySeparatorChar;
+                buffer = buffer.Slice(separator);
+            }
+
+            // skip the following / or \
+            while (separator < source.Length && (source[separator] == Path.DirectorySeparatorChar || source[separator] == Path.AltDirectorySeparatorChar))
+                separator++;
+
+            // next iter
+            source = source.Slice(separator);
+            // append everything else if there`s no more '\' or '/'
+            if (last)
+            {
+                source.CopyTo(buffer);
+                written += source.Length;
+                break;
+            }
+        }
+
+        if (array != null)
+            ArrayPool<char>.Shared.Return(array);
+
+        // why create an empty string when you can reuse it
+        if (written == 0)
+            return string.Empty;
+
+        // remove / at the end of path
+        if (written > 2 && normalized[written - 1] == Path.DirectorySeparatorChar)
+            written--;
+
+        // alloc new path
+        return new string(normalized.Slice(0, written));
+    }
+}

--- a/TruePath.Benchmarks/PathStrings.cs
+++ b/TruePath.Benchmarks/PathStrings.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 //
 // SPDX-License-Identifier: MIT
 

--- a/TruePath.Benchmarks/PathStrings.cs
+++ b/TruePath.Benchmarks/PathStrings.cs
@@ -6,7 +6,7 @@ using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace TruePath;
+namespace TruePath.Benchmarks;
 
 /// <summary>Helper methods to manipulate paths as strings.</summary>
 public static class PathStrings

--- a/TruePath.Benchmarks/Program.cs
+++ b/TruePath.Benchmarks/Program.cs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-using System;
-using System.Security.Cryptography;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
@@ -70,6 +68,6 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        var summary = BenchmarkRunner.Run<NormalizePathBenchmark>();
+        _ = BenchmarkRunner.Run<NormalizePathBenchmark>();
     }
 }

--- a/TruePath.Benchmarks/Program.cs
+++ b/TruePath.Benchmarks/Program.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.md>
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace TruePath.Benchmarks;
+
+public class NormalizePathBenchmark
+{
+    private const int N = 10000;
+
+    public IEnumerable<string> ValuesForInput => new[]
+    {
+        ".", "./foo", "/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z", "a/../../.",
+        "foo/./sdfaadfsf/safd/../fafdasf/asdfads/adsadsa/das/./../.."
+    };
+
+    [ParamsSource(nameof(ValuesForInput))] public string Input { get; set; } = null!;
+
+    [Benchmark]
+    public string[] Normalize1()
+    {
+        var pp = new string[N];
+        for (var i = 0; i < N; ++i)
+        {
+            pp[i] = PathStrings.Normalize1(Input);
+        }
+        return pp;
+    }
+
+    [Benchmark]
+    public string[] Normalize2()
+    {
+        var pp = new string[N];
+        for (int i = 0; i < N; ++i)
+        {
+            pp[i] = PathStrings.Normalize2(Input);
+        }
+        return pp;
+    }
+}
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var summary = BenchmarkRunner.Run<NormalizePathBenchmark>();
+    }
+}

--- a/TruePath.Benchmarks/Program.cs
+++ b/TruePath.Benchmarks/Program.cs
@@ -42,6 +42,28 @@ public class NormalizePathBenchmark
         }
         return pp;
     }
+
+    [Benchmark]
+    public string[] Normalize3()
+    {
+        var pp = new string[N];
+        for (int i = 0; i < N; ++i)
+        {
+            pp[i] = PathStrings.Normalize3(Input);
+        }
+        return pp;
+    }
+
+    [Benchmark]
+    public string[] Normalize4()
+    {
+        var pp = new string[N];
+        for (int i = 0; i < N; ++i)
+        {
+            pp[i] = PathStrings.Normalize4(Input);
+        }
+        return pp;
+    }
 }
 
 public class Program

--- a/TruePath.Benchmarks/TruePath.Benchmarks.csproj
+++ b/TruePath.Benchmarks/TruePath.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<!--
+SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.md>
+
+SPDX-License-Identifier: MIT
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    </ItemGroup>
+
+</Project>

--- a/TruePath.sln
+++ b/TruePath.sln
@@ -52,6 +52,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TruePath", "TruePath\TruePa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TruePath.Tests", "TruePath.Tests\TruePath.Tests.csproj", "{7E3E01D3-19A2-4583-9895-E2AEDC3ED07A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TruePath.Benchmarks", "TruePath.Benchmarks\TruePath.Benchmarks.csproj", "{4FB7CAE4-241F-4DA8-ABC7-699BEAFBC637}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,5 +74,9 @@ Global
 		{7E3E01D3-19A2-4583-9895-E2AEDC3ED07A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E3E01D3-19A2-4583-9895-E2AEDC3ED07A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E3E01D3-19A2-4583-9895-E2AEDC3ED07A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FB7CAE4-241F-4DA8-ABC7-699BEAFBC637}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FB7CAE4-241F-4DA8-ABC7-699BEAFBC637}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FB7CAE4-241F-4DA8-ABC7-699BEAFBC637}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FB7CAE4-241F-4DA8-ABC7-699BEAFBC637}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace TruePath;
@@ -36,6 +37,7 @@ public static class PathStrings
     ///     Note that this operation will never perform any file IO, and is purely string manipulation.
     /// </para>
     /// </summary>
+    [SkipLocalsInit] // is necessary to prevent the CLR from filling stackalloc with zeros.
     public static string Normalize(string path)
     {
         int written = 0;

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -43,7 +43,7 @@ public static class PathStrings
     {
         int written = 0;
 
-        char[]? array = path.Length < (IntPtr.Size == 4 ? 512 : 4096) ? null : ArrayPool<char>.Shared.Rent(path.Length);
+        char[]? array = path.Length <= 512 ? null : ArrayPool<char>.Shared.Rent(path.Length);
 
         Span<char> normalized = array != null ? array.AsSpan() : stackalloc char[path.Length];
         ReadOnlySpan<char> source = path.AsSpan();
@@ -120,9 +120,6 @@ public static class PathStrings
             }
         }
 
-        if (array != null)
-            ArrayPool<char>.Shared.Return(array);
-
         // why create an empty string when you can reuse it
         if (written == 0)
             return string.Empty;
@@ -132,6 +129,9 @@ public static class PathStrings
             written--;
 
         // alloc new path
-        return new string(normalized.Slice(0, written));
+        var result = new string(normalized.Slice(0, written));
+        if (array != null)
+            ArrayPool<char>.Shared.Return(array);
+        return result;
     }
 }

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -38,59 +38,95 @@ public static class PathStrings
     /// </summary>
     public static string Normalize(string path)
     {
-        // TODO[#19]: Optimize this. It is possible to do with less allocations.
-        var segments = new List<(int Start, int End)>();
+        int written = 0;
+        Span<char> normalized = stackalloc char[path.Length];
+        ReadOnlySpan<char> source = path.AsSpan();
 
-        int? currentSegmentStart = 0;
-        for (var i = 0; i < path.Length; i++)
+        var buffer = normalized;
+
+        while (true)
         {
-            if (path[i] == Path.DirectorySeparatorChar || path[i] == Path.AltDirectorySeparatorChar)
+            bool last = false;
+            var separator = source.IndexOf(Path.DirectorySeparatorChar);
+            var altSeparator = source.IndexOf(Path.AltDirectorySeparatorChar);
+
+            if (altSeparator == -1 && separator == -1) { last = true; separator = source.Length - 1; }
+            else if (separator == -1) separator = altSeparator;
+            else separator = Math.Min(separator, altSeparator);
+
+            separator++;
+            var block = source.Slice(0, separator);
+
+            bool skip;
+            // skip if '.'
+            if (block.Length == 1 && block[0] == '.')
+                skip = true;
+            // skip if './'
+            else if (block.Length == 2 && block[0] == '.' && (block[1] == Path.DirectorySeparatorChar || block[1] == Path.AltDirectorySeparatorChar))
+                skip = true;
+            // cut if '..' or '../'
+            else if (written != 0 && block.Length is 2 or 3 && block.StartsWith(".."))
             {
-                if (currentSegmentStart is { } s)
+                var jump = normalized.Slice(0, written - 1).LastIndexOf(Path.DirectorySeparatorChar);
+
+                if (jump == -1 && written > 1)
                 {
-                    segments.Add((s, i));
-                    currentSegmentStart = null;
+                    written = 0;
+                    buffer = normalized;
+                    skip = true;
                 }
+                else if (jump != -1)
+                {
+                    written = jump;
+                    buffer = normalized.Slice(written + 1);
+                    skip = true;
+                }
+                else
+                    skip = false;
             }
             else
+                skip = false;
+
+            // append sliced path
+            if (!skip)
             {
-                currentSegmentStart ??= i;
+                block.CopyTo(buffer);
+                written += separator;
+                // replace \ with / if ends with \
+                if (separator > 0 && buffer[separator - 1] == Path.AltDirectorySeparatorChar)
+                    buffer[separator - 1] = Path.DirectorySeparatorChar;
+                buffer = buffer.Slice(separator);
+            }
+
+            // skip the following / or \
+            while (true)
+            {
+                if (separator < source.Length && (source[separator] == Path.DirectorySeparatorChar || source[separator] == Path.AltDirectorySeparatorChar))
+                    separator++;
+                else
+                    break;
+            }
+
+            // next iter
+            source = source.Slice(separator);
+            // append everything else if there`s no more '\' or '/'
+            if (last)
+            {
+                source.CopyTo(buffer);
+                written += source.Length;
+                break;
             }
         }
 
-        if (currentSegmentStart is { } start)
-            segments.Add((start, path.Length));
+        // why create an empty string when you can reuse it
+        if (written == 0)
+            return string.Empty;
 
-        var resultSegments = new LinkedList<(int Start, int End)>();
-        foreach (var segment in segments)
-        {
-            var text = path.AsSpan()[segment.Start..segment.End];
-            switch (text)
-            {
-                case ".":
-                    continue;
-                case ".." when resultSegments.Count > 0
-                               // check for the root segment (empty)
-                               && resultSegments.Last!.Value.Start != resultSegments.Last.Value.End:
-                    resultSegments.RemoveLast();
-                    break;
-                default:
-                    resultSegments.AddLast(segment);
-                    break;
-            }
-        }
+        // remove / at the end of path
+        if (written > 2 && normalized[written - 1] == Path.DirectorySeparatorChar)
+            written--;
 
-        var buffer = new StringBuilder();
-        var index = 0;
-        foreach (var segment in resultSegments)
-        {
-            buffer.Append(path, segment.Start, segment.End - segment.Start);
-            if (++index < resultSegments.Count
-                // check for the root segment: in such case, we still want to add the separator
-                || segment.Start == segment.End)
-                buffer.Append(Path.DirectorySeparatorChar);
-        }
-
-        return buffer.ToString();
+        // alloc new path
+        return new string(normalized.Slice(0, written));
     }
 }

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -101,13 +101,8 @@ public static class PathStrings
             }
 
             // skip the following / or \
-            while (true)
-            {
-                if (separator < source.Length && (source[separator] == Path.DirectorySeparatorChar || source[separator] == Path.AltDirectorySeparatorChar))
-                    separator++;
-                else
-                    break;
-            }
+            while (separator < source.Length && (source[separator] == Path.DirectorySeparatorChar || source[separator] == Path.AltDirectorySeparatorChar))
+                separator++;
 
             // next iter
             source = source.Slice(separator);

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 //
 // SPDX-License-Identifier: MIT
 

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -4,7 +4,6 @@
 
 using System.Buffers;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace TruePath;
 

--- a/TruePath/TruePath.csproj
+++ b/TruePath/TruePath.csproj
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 
 SPDX-License-Identifier: MIT
 -->

--- a/TruePath/TruePath.csproj
+++ b/TruePath/TruePath.csproj
@@ -9,9 +9,10 @@ SPDX-License-Identifier: MIT
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <PackageDescription>File path abstraction library for .NET.</PackageDescription>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="TruePath.Tests"/>
+        <InternalsVisibleTo Include="TruePath.Tests" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #19.

It doesn't work 100 times faster, but now allocations are at a maximum minimum.
```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22000.2538/21H2/SunValley)
Intel Core i7-7700K CPU 4.20GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK 8.0.200
  [Host]     : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX2
```
| Method    | PATH                 | Mean      | Error    | StdDev   | Ratio | Gen0   | Allocated |
|---------- |--------------------- |----------:|---------:|---------:|------:|-------:|----------:|
| **Optimized** | **.**                    |  **12.49 ns** | **0.130 ns** | **0.115 ns** |  **0.42** |      **-** |         **-** |
| Normalize | .                    |  29.70 ns | 0.635 ns | 0.780 ns |  1.00 | 0.0554 |     232 B |
|           |                      |           |          |          |       |        |           |
| **Optimized** | **./foo**                |  **36.42 ns** | **0.186 ns** | **0.145 ns** |  **0.63** | **0.0076** |      **32 B** 
| Normalize | ./foo                |  57.58 ns | 0.460 ns | 0.408 ns |  1.00 | 0.0745 |     312 B |
|           |                      |           |          |          |       |        |           |
| **Optimized** | **/a/b/(...)b/c/d [56]** | **389.60 ns** | **4.658 ns** | **4.357 ns** |  **0.71** | **0.0248** |     **104 B** |
| Normalize | /a/b/(...)b/c/d [56] | 548.96 ns | 4.046 ns | 3.587 ns |  1.00 | 0.5159 |    2160 B |
|           |                      |           |          |          |       |        |           |
| **Optimized** | **a/../../.**            |  **62.51 ns** | **0.531 ns** | **0.471 ns** |  **0.82** | **0.0076** |      **32 B** |
| Normalize | a/../../.            |  76.48 ns | 0.403 ns | 0.336 ns |  1.00 | 0.0861 |     360 B |
|           |                      |           |          |          |       |        |           |
| **Optimized** | **foo/.(...)ar/.. [25]** | **112.71 ns** | **0.997 ns** | **0.932 ns** |  **0.76** | **0.0095** |      **40 B** |
| Normalize | foo/.(...)ar/.. [25] | 147.87 ns | 1.437 ns | 1.200 ns |  1.00 | 0.1318 |     552 B |