### PR TITLE
Check xml-doc to separate step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,9 @@ jobs:
     - name: Verify encoding
       shell: pwsh
       run: scripts/Test-Encoding.ps1
+  nowarn-empty:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Verify with NoWarn as empty
+      run: dotnet build /p:NoWarn='' --no-incremental

--- a/.github/workflows/main.yml.license
+++ b/.github/workflows/main.yml.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 
 SPDX-License-Identifier: MIT

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,9 +16,11 @@ SPDX-License-Identifier: MIT
     </PropertyGroup>
 
     <PropertyGroup Label="Build">
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <NoWarn>CS0419;CS1570;CS1571;CS1572;CS1573;CS1574;CS1580;CS1581;CS1584;CS1587;CS1589;CS1590;CS1591;CS1592;CS1598;CS1710;CS1711;CS1712;$(NoWarn)</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 
 SPDX-License-Identifier: MIT
 -->

--- a/TruePath.Benchmarks/TruePath.Benchmarks.csproj
+++ b/TruePath.Benchmarks/TruePath.Benchmarks.csproj
@@ -8,9 +8,7 @@ SPDX-License-Identifier: MIT
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/TruePath.Benchmarks/TruePath.Benchmarks.csproj
+++ b/TruePath.Benchmarks/TruePath.Benchmarks.csproj
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.md>
+SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 
 SPDX-License-Identifier: MIT
 -->

--- a/TruePath.Tests/TruePath.Tests.csproj
+++ b/TruePath.Tests/TruePath.Tests.csproj
@@ -7,8 +7,6 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/TruePath.Tests/TruePath.Tests.csproj
+++ b/TruePath.Tests/TruePath.Tests.csproj
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 
 SPDX-License-Identifier: MIT
 -->

--- a/TruePath/TruePath.csproj
+++ b/TruePath/TruePath.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>true</IsPackable>
         <PackageDescription>File path abstraction library for .NET.</PackageDescription>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/scripts/github-actions.fsx
+++ b/scripts/github-actions.fsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 //
 // SPDX-License-Identifier: MIT
 

--- a/scripts/github-actions.fsx
+++ b/scripts/github-actions.fsx
@@ -42,11 +42,19 @@ let workflows = [
 
             step(name = "REUSE license check", uses = "fsfe/reuse-action@v3")
         ]
+
         job "encoding" [
             runsOn ubuntu
             checkout
 
             step(name = "Verify encoding", shell = "pwsh", run = "scripts/Test-Encoding.ps1")
+        ]
+
+        job "nowarn-empty" [
+            runsOn ubuntu
+            checkout
+
+            step(name = "Verify with NoWarn as empty", run = "dotnet build /p:NoWarn='' --no-incremental")
         ]
     ]
 


### PR DESCRIPTION
Added warnings for XML documentation to the NoWarn property and check with separate job

- https://github.com/rstm-sf/TruePath/actions/runs/8951253702 fail
- https://github.com/rstm-sf/TruePath/actions/runs/8951265906 success

Closes #51