### PR TITLE
(#16) Add Support for Windows Disk Drives in Normalization Algorithm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- [#16: Support Windows disk drives in the normalization algorithm](https://github.com/ForNeVeR/TruePath/issues/16).
+
+  Thanks to @Kataane.
+
 ## [1.3.0] - 2024-06-21
 ### Added
 - [#39: Add `AbsolutePath::RelativeTo`](https://github.com/ForNeVeR/TruePath/issues/39).

--- a/TruePath.Benchmarks/Program.cs
+++ b/TruePath.Benchmarks/Program.cs
@@ -62,6 +62,17 @@ public class NormalizePathBenchmark
         }
         return pp;
     }
+
+    [Benchmark]
+    public string[] NormalizeWithWindowsDiskDrive()
+    {
+        var pp = new string[N];
+        for (int i = 0; i < N; ++i)
+        {
+            pp[i] = PathStrings.NormalizeWithWindowsDiskDrive(Input);
+        }
+        return pp;
+    }
 }
 
 public class Program

--- a/TruePath.Tests/PathStringsTests.cs
+++ b/TruePath.Tests/PathStringsTests.cs
@@ -62,17 +62,55 @@ public class PathStringsTests
         Assert.Equal(NormalizeSeparators(expected), PathStrings.Normalize(input));
     }
 
-    [Theory(Skip = "TODO[#16]: Make it work properly")]
-    [InlineData("C:.", "C:")]
-    [InlineData("C:./foo", "C:foo")]
-    [InlineData("C:..", "C:..")]
-    [InlineData("C:/..", "C:/..")]
+    [Theory]
+    [InlineData(".", "")]
+    [InlineData("./foo", "foo")]
+    [InlineData("..", "..")]
+    [InlineData("./..", "..")]
+    [InlineData("a/..", "")]
+    [InlineData("a/../..", "..")]
+    [InlineData("a/../../.", "..")]
+    [InlineData("a/../../..", "../..")]
+    [InlineData("foo/./bar/../var/./dar/..", "foo/var")]
+    [InlineData("foo/.bar", "foo/.bar")]
+    [InlineData("/.", "/")]
+    [InlineData("/..", "/..")]
+    [InlineData("/../..", "/../..")]
+    [InlineData("/../../foo/..", "/../..")]
+    [InlineData("x/foo/bar/../..", "x")]
+    [InlineData("x/foo/bar/.../.", "x/foo/bar/...")]
+    [InlineData("x/foo/..bar/", "x/foo/..bar")]
+    [InlineData("../../foo", "../../foo")]
+    [InlineData("../../../foo", "../../../foo")]
+    [InlineData("../foo/..", "..")]
     public void WindowsSpecificDotFoldersAreTraversed(string input, string expected)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
-        Assert.Equal(NormalizeSeparators(expected), PathStrings.Normalize(input));
+
+        // Arrange
+        var driveLetter = RandomDriveLetter();
+        input = driveLetter + input;
+        expected = driveLetter + expected;
+
+        //Act
+        var actual = PathStrings.Normalize(input);
+
+        // Assert
+        Assert.Equal(NormalizeSeparators(expected), actual);
     }
 
     private static string NormalizeSeparators(string path) =>
         path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+    private static string RandomDriveLetter()
+    {
+        var rnd = new Random(Guid.NewGuid().GetHashCode());
+
+        int lowerBound = Convert.ToInt16('A');
+        int upperBound = Convert.ToInt16('Z');
+
+        var letterIndex = rnd.Next(lowerBound, upperBound + 1); // include upperBound
+
+        return Convert.ToChar(letterIndex) + ":";
+    }
 }

--- a/TruePath.Tests/PathStringsTests.cs
+++ b/TruePath.Tests/PathStringsTests.cs
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: MIT
 
 using System.Runtime.InteropServices;
+using Xunit.Abstractions;
 
 namespace TruePath.Tests;
 
-public class PathStringsTests
+public class PathStringsTests(ITestOutputHelper output)
 {
     [Fact]
     public void SlashesShouldBeNormalized()
@@ -92,6 +93,8 @@ public class PathStringsTests
         input = driveLetter + input;
         expected = driveLetter + expected;
 
+        output.WriteLine($"{driveLetter} is selected as the drive letter.");
+
         //Act
         var actual = PathStrings.Normalize(input);
 
@@ -111,6 +114,13 @@ public class PathStringsTests
 
         var letterIndex = rnd.Next(lowerBound, upperBound + 1); // include upperBound
 
-        return Convert.ToChar(letterIndex) + ":";
+        var letter = Convert.ToChar(letterIndex);
+
+        if (rnd.NextSingle() >= 0.5)
+        {
+            letter = char.ToLower(letter);
+        }
+
+        return letter + ":";
     }
 }

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -133,7 +133,6 @@ public static class PathStrings
             }
         }
 
-        // why create an empty string when you can reuse it
         if (written == 0 && containsDriveLetter)
         {
             return new string(path.AsSpan(0, 2));

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -4,14 +4,13 @@
 
 using System.Buffers;
 using System.Runtime.CompilerServices;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace TruePath;
 
 /// <summary>Helper methods to manipulate paths as strings.</summary>
 public static class PathStrings
 {
-    private static readonly SearchValues<char> DriveLetters = SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    private static readonly SearchValues<char> DriveLetters = SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
 
     /// <summary>
     /// <para>

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -4,12 +4,15 @@
 
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace TruePath;
 
 /// <summary>Helper methods to manipulate paths as strings.</summary>
 public static class PathStrings
 {
+    private static readonly SearchValues<char> DriveLetters = SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
     /// <summary>
     /// <para>
     ///     Will convert a path string to a normalized path, using path separator specific for the current system.
@@ -40,12 +43,14 @@ public static class PathStrings
     [SkipLocalsInit] // is necessary to prevent the CLR from filling stackalloc with zeros.
     public static string Normalize(string path)
     {
+        bool containsDriveLetter = SourceContainsDriveLetter(path.AsSpan());
+
         int written = 0;
 
         char[]? array = path.Length <= 512 ? null : ArrayPool<char>.Shared.Rent(path.Length);
 
         Span<char> normalized = array != null ? array.AsSpan() : stackalloc char[path.Length];
-        ReadOnlySpan<char> source = path.AsSpan();
+        ReadOnlySpan<char> source = containsDriveLetter ? path.AsSpan()[2..] : path.AsSpan();
 
         var buffer = normalized;
 
@@ -130,17 +135,53 @@ public static class PathStrings
         }
 
         // why create an empty string when you can reuse it
+        if (written == 0 && containsDriveLetter)
+        {
+            return new string(path.AsSpan(0, 2));
+        }
+
         if (written == 0)
+        {
             return string.Empty;
+        }
 
         // remove / at the end of path
         if (written > 2 && normalized[written - 1] == Path.DirectorySeparatorChar)
             written--;
 
         // alloc new path
-        var result = new string(normalized.Slice(0, written));
+        string? result;
+
+        if (containsDriveLetter)
+        {
+            var normalizedRef = new ReadOnlySpan<char>(normalized.ToArray(), 0, written);
+            result = string.Concat(path.AsSpan(0, 2), normalizedRef.Slice(0, written));
+        }
+        else
+        {
+            result = new string(normalized.Slice(0, written));
+        }
+
+        normalized.Slice(0, written);
         if (array != null)
             ArrayPool<char>.Shared.Return(array);
         return result;
+    }
+
+    /// <summary>
+    /// Determines whether the specified source contains a drive letter.
+    /// </summary>
+    /// <param name="source">A read-only span of characters to be checked.</param>
+    /// <returns>
+    ///   <c>true</c> if the source contains a drive letter (e.g., 'C:'); otherwise, <c>false</c>.
+    /// </returns>
+    private static bool SourceContainsDriveLetter(ReadOnlySpan<char> source)
+    {
+        if (source.Length < 2) return false;
+
+        var letter = source[0];
+        var colon = source[1];
+
+        return DriveLetters.Contains(letter) && colon == ':';
     }
 }


### PR DESCRIPTION
Hi!

Thanks for all the hard work you do for the .NET community. I hope this contribution is helpful.

This pull request includes a few changes to improve path normalization for Windows disk drives:

### Changes

- **New Method:** Added `SourceContainsDriveLetter` to check if the source path has a drive letter. This helps normalize Windows paths correctly.
- **Updated Tests:** Re-enabled `WindowsSpecificDotFoldersAreTraversed` to check Windows-specific paths.
- **Benchmark Additions:** Added a benchmark for `PathStrings.Normalize` with the new `SourceContainsDriveLetter` logic to measure performance.

### Benchmark Results

| Method                        | Input                | Mean       | Error    | StdDev   |
|------------------------------ |--------------------- |-----------:|---------:|---------:|
| Normalize1                    | .                    |   250.3 us |  4.88 us |  9.05 us |
| Normalize2                    | .                    |   103.4 us |  1.59 us |  1.49 us |
| Normalize3                    | .                    |   144.8 us |  2.90 us |  6.23 us |
| Normalize4                    | .                    |   279.9 us |  2.04 us |  1.70 us |
| NormalizeWithWindowsDiskDrive | .                    |   106.7 us |  1.22 us |  1.08 us |
| Normalize1                    | ./foo                |   514.0 us |  2.89 us |  2.70 us |
| Normalize2                    | ./foo                |   265.5 us |  3.11 us |  2.91 us |
| Normalize3                    | ./foo                |   311.8 us |  1.65 us |  1.54 us |
| Normalize4                    | ./foo                |   604.0 us |  4.97 us |  4.40 us |
| NormalizeWithWindowsDiskDrive | ./foo                |   305.8 us |  2.25 us |  2.11 us |
| Normalize1                    | /a/b/(...)x/y/z [52] | 5,595.6 us | 55.67 us | 49.35 us |
| Normalize2                    | /a/b/(...)x/y/z [52] | 2,949.7 us | 10.64 us |  9.95 us |
| Normalize3                    | /a/b/(...)x/y/z [52] | 2,795.8 us | 14.97 us | 13.27 us |
| Normalize4                    | /a/b/(...)x/y/z [52] | 5,985.2 us | 39.87 us | 35.34 us |
| NormalizeWithWindowsDiskDrive | /a/b/(...)x/y/z [52] | 2,938.2 us | 19.28 us | 18.04 us |
| Normalize1                    | a/../../.            |   668.9 us |  1.76 us |  1.65 us |
| Normalize2                    | a/../../.            |   433.7 us |  2.54 us |  2.25 us |
| Normalize3                    | a/../../.            |   478.1 us |  2.36 us |  2.09 us |
| Normalize4                    | a/../../.            | 1,010.1 us | 18.64 us | 17.43 us |
| NormalizeWithWindowsDiskDrive | a/../../.            |   479.1 us |  4.06 us |  3.17 us |
| Normalize1                    | foo/.(...)../.. [59] | 2,471.2 us | 39.56 us | 37.00 us |
| Normalize2                    | foo/.(...)../.. [59] | 1,221.5 us | 16.20 us | 15.15 us |
| Normalize3                    | foo/.(...)../.. [59] | 1,267.2 us | 24.31 us | 26.02 us |
| Normalize4                    | foo/.(...)../.. [59] | 2,786.9 us | 19.80 us | 17.55 us |
| NormalizeWithWindowsDiskDrive | foo/.(...)../.. [59] | 1,319.2 us |  4.33 us |  3.84 us |

Before my changes, the code behaved similarly to `Normalize2`. After the changes, the speed is within the error margins.

### Questions

1. Should handle incorrectly entered drive letters (e.g., "C/...." or ":/...")?
2. Since these changes are Windows-specific, should we use preprocessor directives to exclude this code on other systems?
3. Should drive letters be case-insensitive, as they are now treated as uppercase?

---

Closes #16.