### PR TITLE
(#21) Add method to return canonical path forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   Thanks to @Kataane.
 
+### Added
+- `DiskUtils::GetRealPath` to converts paths' case to correct, resolve relative paths, resolve symlinks.
+
+  Thanks to @Kataane.
+
 ## [1.3.0] - 2024-06-21
 ### Added
 - [#39: Add `AbsolutePath::RelativeTo`](https://github.com/ForNeVeR/TruePath/issues/39).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   Thanks to @Kataane.
 
 ### Added
-- `DiskUtils::GetRealPath` to converts paths' case to correct, resolve relative paths, resolve symlinks.
+- `AbsolutePath::Canonicalize` to convert the path to absolute, convert to correct case on case-insensitive file systems, resolve symlinks.
 
   Thanks to @Kataane.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Aside from the strict types, the following features are supported for the paths:
 - `IPath<T>` supports operators to join it with `LocalPath` or a `string` (note that in both cases appending an absolute path to path of another kind will take over: the last absolute path in chain will win and destroy all the previous ones; this is the standard behavior of path-combining methods — use `AbsolutePath` in combination with `RelativePath` if you want to avoid this behavior);
 - `IPath::IsPrefixOf` to check path prefixes;
 - `IPath::StartsWith` to check if the current path starts with a specified path;
+- `AbsolutePath::Canonicalize` to convert the path to absolute, convert to correct case on case-insensitive file systems, resolve symlinks.
 - `LocalPath::IsAbsolute` to check the path kind (since it supports both kinds);
 - `AbsolutePath::RelativeTo`, `LocalPath::RelativeTo` to get a relative part between two paths, if possible;
 - extension methods on `IPath`:
@@ -85,9 +86,6 @@ Aside from the strict types, the following features are supported for the paths:
   - `GetFileNameWithoutExtension` to get the file name without the extension (and without the trailing dot, if any)
 
     (Note how `GetFileNameWithoutExtension()` works nicely together with `GetExtensionWithDot()` to reconstruct the resulting path from their concatenation, however weird the initial name was — no extension, trailing dot, no base name.)
-
-### `DiskUtils`
-- `DiskUtils::GetRealPath` converts case to correct, resolves relative paths, resolves symlinks.
 
 Documentation
 -------------

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Aside from the strict types, the following features are supported for the paths:
 
     (Note how `GetFileNameWithoutExtension()` works nicely together with `GetExtensionWithDot()` to reconstruct the resulting path from their concatenation, however weird the initial name was — no extension, trailing dot, no base name.)
 
+### `DiskUtils`
+- `DiskUtils::GetRealPath` converts case to correct, resolves relative paths, resolves symlinks.
+
 Documentation
 -------------
 - [Contributor Guide][docs.contributing]

--- a/TruePath.Tests/AbsolutePathTests.cs
+++ b/TruePath.Tests/AbsolutePathTests.cs
@@ -110,7 +110,7 @@ public class AbsolutePathTests
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
 
-        var newDirectory = new AbsolutePath(Path.GetTempFileName());
+        var newDirectory = new AbsolutePath(Path.GetTempFileName()).Canonicalize();
         File.Delete(newDirectory.ToString());
         newDirectory /= "foobar";
         Directory.CreateDirectory(newDirectory.Value);

--- a/TruePath.Tests/AbsolutePathTests.cs
+++ b/TruePath.Tests/AbsolutePathTests.cs
@@ -104,4 +104,19 @@ public class AbsolutePathTests
 
         Assert.Equal(expected, relativePath.Value);
     }
+
+    [Fact]
+    public void CanonicalizationCaseOnMacOs()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
+
+        var newDirectory = new AbsolutePath(Path.GetTempPath());
+        File.Delete(newDirectory.ToString());
+        newDirectory /= "foobar";
+        Directory.CreateDirectory(newDirectory.Value);
+
+        var incorrectCaseDirectory = newDirectory.Parent!.Value / "FOOBAR";
+        var result = incorrectCaseDirectory.Canonicalize();
+        Assert.Equal(newDirectory.Value, result.Value);
+    }
 }

--- a/TruePath.Tests/AbsolutePathTests.cs
+++ b/TruePath.Tests/AbsolutePathTests.cs
@@ -110,7 +110,7 @@ public class AbsolutePathTests
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
 
-        var newDirectory = new AbsolutePath(Path.GetTempPath());
+        var newDirectory = new AbsolutePath(Path.GetTempFileName());
         File.Delete(newDirectory.ToString());
         newDirectory /= "foobar";
         Directory.CreateDirectory(newDirectory.Value);

--- a/TruePath.Tests/DiskUtilsTests.cs
+++ b/TruePath.Tests/DiskUtilsTests.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
+//
+// SPDX-License-Identifier: MIT
+
 using RuntimeInformation = System.Runtime.InteropServices.RuntimeInformation;
 
 namespace TruePath.Tests;
@@ -58,6 +62,21 @@ public class DiskUtilsTests
 
         // Assert
         Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DiskUtils_MacOs_PassBackPath_ReturnCanonicalPath()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
+
+        var newDirectory = new AbsolutePath(Path.GetTempPath());
+        File.Delete(newDirectory.ToString());
+        newDirectory /= "foobar";
+        Directory.CreateDirectory(newDirectory.Value);
+
+        var incorrectCaseDirectory = newDirectory.Parent!.Value / "FOOBAR";
+        var result = DiskUtils.GetRealPath(incorrectCaseDirectory.Value);
+        Assert.Equal(newDirectory.Value, result);
     }
 
     private static string Back(List<string> folders, int stepsBack, string delimiter)

--- a/TruePath.Tests/DiskUtilsTests.cs
+++ b/TruePath.Tests/DiskUtilsTests.cs
@@ -64,21 +64,6 @@ public class DiskUtilsTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact]
-    public void DiskUtils_MacOs_PassBackPath_ReturnCanonicalPath()
-    {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
-
-        var newDirectory = new AbsolutePath(Path.GetTempPath());
-        File.Delete(newDirectory.ToString());
-        newDirectory /= "foobar";
-        Directory.CreateDirectory(newDirectory.Value);
-
-        var incorrectCaseDirectory = newDirectory.Parent!.Value / "FOOBAR";
-        var result = DiskUtils.GetRealPath(incorrectCaseDirectory.Value);
-        Assert.Equal(newDirectory.Value, result);
-    }
-
     private static string Back(List<string> folders, int stepsBack, string delimiter)
     {
         int finalIndex = folders.Count - stepsBack - 1;

--- a/TruePath.Tests/DiskUtilsTests.cs
+++ b/TruePath.Tests/DiskUtilsTests.cs
@@ -18,7 +18,7 @@ public class DiskUtilsTests
         var nonCanonicalPath = new string(currentDirectory) + string.Concat(Enumerable.Repeat(@"\..", back));
 
         // Act
-        var actual = DiskUtils.GetWindowsRealPathByPath(nonCanonicalPath);
+        var actual = DiskUtils.GetWindowsRealPath(nonCanonicalPath);
 
         // Assert
         Assert.Equal(expected, actual);
@@ -34,7 +34,7 @@ public class DiskUtilsTests
         var nonCanonicalPath = new string(MakeNonCanonicalPath(expected).ToArray());
 
         // Act
-        var actual = DiskUtils.GetWindowsRealPathByPath(nonCanonicalPath);
+        var actual = DiskUtils.GetWindowsRealPath(nonCanonicalPath);
 
         // Assert
         Assert.Equal(expected, actual);

--- a/TruePath.Tests/DiskUtilsTests.cs
+++ b/TruePath.Tests/DiskUtilsTests.cs
@@ -18,7 +18,7 @@ public class DiskUtilsTests
         var nonCanonicalPath = new string(currentDirectory) + string.Concat(Enumerable.Repeat(@"\..", back));
 
         // Act
-        var actual = DiskUtils.GetWindowsRealPath(nonCanonicalPath);
+        var actual = DiskUtils.GetRealPath(nonCanonicalPath);
 
         // Assert
         Assert.Equal(expected, actual);
@@ -34,7 +34,7 @@ public class DiskUtilsTests
         var nonCanonicalPath = new string(MakeNonCanonicalPath(expected).ToArray());
 
         // Act
-        var actual = DiskUtils.GetWindowsRealPath(nonCanonicalPath);
+        var actual = DiskUtils.GetRealPath(nonCanonicalPath);
 
         // Assert
         Assert.Equal(expected, actual);
@@ -54,7 +54,7 @@ public class DiskUtilsTests
         var nonCanonicalPath = new string(currentDirectory) + string.Concat(Enumerable.Repeat("/..", back));
 
         // Act
-        var actual = DiskUtils.GetPosixRealPath(nonCanonicalPath);
+        var actual = DiskUtils.GetRealPath(nonCanonicalPath);
 
         // Assert
         Assert.Equal(expected, actual);

--- a/TruePath.Tests/DiskUtilsTests.cs
+++ b/TruePath.Tests/DiskUtilsTests.cs
@@ -1,9 +1,31 @@
+using RuntimeInformation = System.Runtime.InteropServices.RuntimeInformation;
+
 namespace TruePath.Tests;
 
 public class DiskUtilsTests
 {
     [Fact]
-    public void DiskUtils_OnWindows_PassPath_ReturnCanonicalPath()
+    public void DiskUtils_OnWindows_PassBackPath_ReturnCanonicalPath()
+    {
+        // Arrange
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+
+        var currentDirectory = Environment.CurrentDirectory;
+        var directories = currentDirectory.Split(@"\").ToList();
+        var back = Random.Shared.Next(directories.Count);
+        var expected = Back(directories, back, @"\");
+
+        var nonCanonicalPath = new string(currentDirectory) + string.Concat(Enumerable.Repeat(@"\..", back));
+
+        // Act
+        var actual = DiskUtils.GetWindowsRealPathByPath(nonCanonicalPath);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DiskUtils_OnWindows_PassNonCanonicalPath_ReturnCanonicalPath()
     {
         // Arrange
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
@@ -19,19 +41,36 @@ public class DiskUtilsTests
     }
 
     [Fact]
-    public void DiskUtils_NonWindows_PassPath_ReturnCanonicalPath()
+    public void DiskUtils_Posix_PassBackPath_ReturnCanonicalPath()
     {
         // Arrange
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
 
-        var expected = Environment.CurrentDirectory;
-        var nonCanonicalPath = new string(MakeNonCanonicalPath(expected).ToArray());
+        var currentDirectory = Environment.CurrentDirectory;
+        var directories = currentDirectory.Split("/").ToList();
+        var back = Random.Shared.Next(directories.Count);
+        var expected = Back(directories, back, "/");
+
+        var nonCanonicalPath = new string(currentDirectory) + string.Concat(Enumerable.Repeat("/..", back));
 
         // Act
         var actual = DiskUtils.GetPosixRealPath(nonCanonicalPath);
 
         // Assert
         Assert.Equal(expected, actual);
+    }
+
+    private static string Back(List<string> folders, int stepsBack, string delimiter)
+    {
+        int finalIndex = folders.Count - stepsBack - 1;
+        List<string> finalFolders = folders[..(finalIndex + 1)];
+
+        if (finalFolders.Count == 1)
+        {
+            return delimiter;
+        }
+
+        return string.Join(delimiter, finalFolders);
     }
 
     private static IEnumerable<char> MakeNonCanonicalPath(string path)

--- a/TruePath.Tests/DiskUtilsTests.cs
+++ b/TruePath.Tests/DiskUtilsTests.cs
@@ -1,0 +1,50 @@
+namespace TruePath.Tests;
+
+public class DiskUtilsTests
+{
+    [Fact]
+    public void DiskUtils_OnWindows_PassPath_ReturnCanonicalPath()
+    {
+        // Arrange
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+
+        var expected = Environment.CurrentDirectory;
+        var nonCanonicalPath = new string(MakeNonCanonicalPath(expected).ToArray());
+
+        // Act
+        var actual = DiskUtils.GetWindowsRealPathByPath(nonCanonicalPath);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DiskUtils_NonWindows_PassPath_ReturnCanonicalPath()
+    {
+        // Arrange
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+
+        var expected = Environment.CurrentDirectory;
+        var nonCanonicalPath = new string(MakeNonCanonicalPath(expected).ToArray());
+
+        // Act
+        var actual = DiskUtils.GetPosixRealPath(nonCanonicalPath);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    private static IEnumerable<char> MakeNonCanonicalPath(string path)
+    {
+        foreach (var @char in path)
+        {
+            if (char.IsLetter(@char) && Random.Shared.NextSingle() >= 0.5)
+            {
+                yield return char.ToUpper(@char);
+                continue;
+            }
+
+            yield return @char;
+        }
+    }
+}

--- a/TruePath.Tests/GlobalUsings.cs
+++ b/TruePath.Tests/GlobalUsings.cs
@@ -2,4 +2,5 @@
 //
 // SPDX-License-Identifier: MIT
 
+global using System.Runtime.InteropServices;
 global using Xunit;

--- a/TruePath.Tests/PathStringsTests.cs
+++ b/TruePath.Tests/PathStringsTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
 //
 // SPDX-License-Identifier: MIT
 

--- a/TruePath.Tests/PathStringsTests.cs
+++ b/TruePath.Tests/PathStringsTests.cs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-using System.Runtime.InteropServices;
-
 namespace TruePath.Tests;
 
 public class PathStringsTests

--- a/TruePath.Tests/PathStringsTests.cs
+++ b/TruePath.Tests/PathStringsTests.cs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+using Xunit.Abstractions;
+
 namespace TruePath.Tests;
 
 public class PathStringsTests(ITestOutputHelper output)

--- a/TruePath/AbsolutePath.cs
+++ b/TruePath/AbsolutePath.cs
@@ -78,6 +78,11 @@ public readonly struct AbsolutePath : IEquatable<AbsolutePath>, IPath, IPath<Abs
     /// <returns>The relative path from the base path to this path.</returns>
     public LocalPath RelativeTo(AbsolutePath basePath) => new(Path.GetRelativePath(basePath.Value, Value));
 
+    /// <summary>
+    /// Converts the path to absolute, corrects the file name case on case-insensitive file systems, resolves symlinks.
+    /// </summary>
+    public AbsolutePath Canonicalize() => new(DiskUtils.GetRealPath(Value));
+
     /// <remarks>
     /// Note that in case path <paramref name="b"/> is <b>absolute</b>, it will completely take over and the
     /// <paramref name="basePath"/> will be ignored.

--- a/TruePath/DiskUtils.cs
+++ b/TruePath/DiskUtils.cs
@@ -1,0 +1,167 @@
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Text;
+
+// ReSharper disable InconsistentNaming
+
+namespace TruePath;
+
+public static unsafe partial class Syscall
+{
+    private const string LIBC_6 = "libc";
+
+    [LibraryImport(LIBC_6, SetLastError = true)]
+    public static partial int readlink(
+        [MarshalAs(UnmanagedType.LPStr)] string path,
+        byte* buffer, int bufferSize);
+}
+
+public static class DiskUtils
+{
+    // from https://github.com/dotnet/corefx/blob/9c06da6a34fcefa6fb37776ac57b80730e37387c/src/Common/src/System/IO/PathInternal.Windows.cs#L52
+    public const short WindowsMaxPath = short.MaxValue;
+
+    public const int LinuxMaxPath = 4096;
+
+    public static string GetAutoRealPath(string path)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return GetWindowsRealPathByPath(path);
+        }
+
+        return GetPosixRealPath(path);
+    }
+
+    public static unsafe string GetPosixRealPath(string path)
+    {
+        var byteArray = ArrayPool<byte>.Shared.Rent(LinuxMaxPath);
+
+        fixed (byte* buffer = byteArray)
+        {
+            var result = Syscall.readlink(path, buffer, LinuxMaxPath);
+            if (result == -1)
+            {
+                ArrayPool<byte>.Shared.Return(byteArray);
+
+                // not a symbolic link
+                return path;
+            }
+
+            var realPath = Encoding.UTF8.GetString(byteArray, 0, result);
+
+            ArrayPool<byte>.Shared.Return(byteArray);
+
+            return realPath;
+        }
+    }
+
+    public static string GetWindowsRealPathByPath(string path)
+    {
+        var handle = CreateFile(path,
+            FILE_READ_EA,
+            FileShare.Read,
+            IntPtr.Zero,
+            FileMode.Open,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            IntPtr.Zero);
+
+        if (handle == INVALID_HANDLE_VALUE)
+        {
+            return path;
+        }
+
+        try
+        {
+            return GetWindowsRealPathByHandle(handle) ?? path;
+        }
+        finally
+        {
+            CloseHandle(handle);
+        }
+    }
+
+    private static unsafe string? GetWindowsRealPathByHandle(IntPtr handle)
+    {
+        // this is called for each storage environment for the Data, Journals and Temp paths
+        // WindowsMaxPath is 32K and although this is called only once we can have a lot of storage environments
+        if (GetPath(256, out var realPath) == false)
+        {
+            if (GetPath((uint)WindowsMaxPath, out realPath) == false)
+                return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(realPath))
+        {
+            return null;
+        }
+
+        //The string that is returned by this function uses the \?\ syntax
+        if (realPath.Length >= 8 && realPath.AsSpan().StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase))
+        {
+            // network path, replace `\\?\UNC\` with `\\`
+            realPath = string.Concat("\\", realPath.AsSpan(7));
+        }
+
+        if (realPath.Length >= 4 && realPath.AsSpan().StartsWith(@"\\?\", StringComparison.OrdinalIgnoreCase))
+        {
+            // local path, remove `\\?\`
+            realPath = realPath.AsSpan(4).ToString();
+        }
+
+        return realPath;
+
+        bool GetPath(uint bufferSize, out string? outputPath)
+        {
+            var charArray = ArrayPool<char>.Shared.Rent((int)bufferSize);
+
+            fixed (char* buffer = charArray)
+            {
+                var result = GetFinalPathNameByHandle(handle, buffer, bufferSize, 0);
+                if (result == 0)
+                {
+                    outputPath = null;
+                    ArrayPool<char>.Shared.Return(charArray);
+                    return false;
+                }
+
+                // return value is the size of the path
+                if (result > bufferSize)
+                {
+                    outputPath = null;
+                    ArrayPool<char>.Shared.Return(charArray);
+                    return false;
+                }
+
+                outputPath = new string(charArray, 0, (int)result);
+                ArrayPool<char>.Shared.Return(charArray);
+                return true;
+            }
+        }
+    }
+
+    private const uint FILE_READ_EA = 0x0008;
+    private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x2000000;
+    private static readonly IntPtr INVALID_HANDLE_VALUE = new(-1);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateFile(
+        [MarshalAs(UnmanagedType.LPTStr)] string filename,
+        [MarshalAs(UnmanagedType.U4)] uint access,
+        [MarshalAs(UnmanagedType.U4)] FileShare share,
+        IntPtr securityAttributes, // optional SECURITY_ATTRIBUTES struct or IntPtr.Zero
+        [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
+        [MarshalAs(UnmanagedType.U4)] uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern unsafe uint GetFinalPathNameByHandle(
+        IntPtr hFile,
+        char* buffer,
+        uint bufferLength,
+        uint dwFlags);
+}

--- a/TruePath/DiskUtils.cs
+++ b/TruePath/DiskUtils.cs
@@ -49,7 +49,7 @@ public static partial class DiskUtils
     /// </summary>
     /// <param name="path">The file path to resolve.</param>
     /// <returns>The resolved absolute path.</returns>
-    public static string GetRealPath(string path)
+    internal static string GetRealPath(string path)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {

--- a/TruePath/DiskUtils.cs
+++ b/TruePath/DiskUtils.cs
@@ -1,28 +1,26 @@
 using System.Buffers;
 using System.Runtime.InteropServices;
-using System.Text;
+using System.Runtime.InteropServices.Marshalling;
+using Microsoft.Win32.SafeHandles;
 
 // ReSharper disable InconsistentNaming
 
 namespace TruePath;
 
-public static unsafe partial class Syscall
+public static partial class Syscall
 {
-    private const string LIBC_6 = "libc";
-
-    [LibraryImport(LIBC_6, SetLastError = true)]
-    public static partial int readlink(
-        [MarshalAs(UnmanagedType.LPStr)] string path,
-        byte* buffer, int bufferSize);
+    [LibraryImport("libc",
+        EntryPoint = "realpath",
+        SetLastError = true,
+        StringMarshalling = StringMarshalling.Custom,
+        StringMarshallingCustomType = typeof(AnsiStringMarshaller))]
+    internal static partial SafeFileHandle realpath(string path, IntPtr buffer);
 }
 
-public static class DiskUtils
+public static partial class DiskUtils
 {
     // from https://github.com/dotnet/corefx/blob/9c06da6a34fcefa6fb37776ac57b80730e37387c/src/Common/src/System/IO/PathInternal.Windows.cs#L52
     public const short WindowsMaxPath = short.MaxValue;
-
-    public const int LinuxMaxPath = 4096;
-
     public static string GetAutoRealPath(string path)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -33,52 +31,36 @@ public static class DiskUtils
         return GetPosixRealPath(path);
     }
 
-    public static unsafe string GetPosixRealPath(string path)
+    public static string GetPosixRealPath(string path)
     {
-        var byteArray = ArrayPool<byte>.Shared.Rent(LinuxMaxPath);
+        using var ptr = Syscall.realpath(path, IntPtr.Zero);
 
-        fixed (byte* buffer = byteArray)
-        {
-            var result = Syscall.readlink(path, buffer, LinuxMaxPath);
-            if (result == -1)
-            {
-                ArrayPool<byte>.Shared.Return(byteArray);
-
-                // not a symbolic link
-                return path;
-            }
-
-            var realPath = Encoding.UTF8.GetString(byteArray, 0, result);
-
-            ArrayPool<byte>.Shared.Return(byteArray);
-
-            return realPath;
-        }
-    }
-
-    public static string GetWindowsRealPathByPath(string path)
-    {
-        var handle = CreateFile(path,
-            FILE_READ_EA,
-            FileShare.Read,
-            IntPtr.Zero,
-            FileMode.Open,
-            FILE_FLAG_BACKUP_SEMANTICS,
-            IntPtr.Zero);
-
-        if (handle == INVALID_HANDLE_VALUE)
+        if (ptr.DangerousGetHandle() == IntPtr.Zero)
         {
             return path;
         }
 
-        try
+        var result = Marshal.PtrToStringAnsi(ptr.DangerousGetHandle());
+
+        return result ?? path;
+    }
+
+    public static string GetWindowsRealPathByPath(string path)
+    {
+        using var handle = CreateFile(path,
+            FileAccess.ReadEa,
+            FileShare.Read,
+            IntPtr.Zero,
+            FileMode.Open,
+            FileAttributes.BackupSemantics,
+            IntPtr.Zero);
+
+        if (handle.IsInvalid)
         {
-            return GetWindowsRealPathByHandle(handle) ?? path;
+            return path;
         }
-        finally
-        {
-            CloseHandle(handle);
-        }
+
+        return GetWindowsRealPathByHandle(handle.DangerousGetHandle()) ?? path;
     }
 
     private static unsafe string? GetWindowsRealPathByHandle(IntPtr handle)
@@ -117,7 +99,7 @@ public static class DiskUtils
 
             fixed (char* buffer = charArray)
             {
-                var result = GetFinalPathNameByHandle(handle, buffer, bufferSize, 0);
+                var result = GetFinalPathNameByHandle(handle, buffer, bufferSize);
                 if (result == 0)
                 {
                     outputPath = null;
@@ -140,28 +122,188 @@ public static class DiskUtils
         }
     }
 
-    private const uint FILE_READ_EA = 0x0008;
-    private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x2000000;
-    private static readonly IntPtr INVALID_HANDLE_VALUE = new(-1);
+    [Flags]
+    internal enum FileAttributes : uint
+    {
+        /// <summary>FILE_ATTRIBUTE_ARCHIVE</summary>
+        Archive = 0x20,
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern IntPtr CreateFile(
+        /// <summary>FILE_ATTRIBUTE_COMPRESSED</summary>
+        Compressed = 0x800,
+
+        /// <summary>FILE_ATTRIBUTE_DEVICE</summary>
+        Device = 0x40,
+
+        /// <summary>FILE_ATTRIBUTE_DIRECTORY</summary>
+        Directory = 0x10,
+
+        /// <summary>FILE_ATTRIBUTE_ENCRYPTED</summary>
+        Encrypted = 0x4000,
+
+        /// <summary>FILE_ATTRIBUTE_HIDDEN</summary>
+        Hidden = 0x02,
+
+        /// <summary>FILE_ATTRIBUTE_INTEGRITY_STREAM</summary>
+        IntegrityStream = 0x8000,
+
+        /// <summary>FILE_ATTRIBUTE_NORMAL</summary>
+        Normal = 0x80,
+
+        /// <summary>FILE_ATTRIBUTE_NOT_CONTENT_INDEXED</summary>
+        NotContentIndexed = 0x2000,
+
+        /// <summary>FILE_ATTRIBUTE_NO_SCRUB_DATA</summary>
+        NoScrubData = 0x20000,
+
+        /// <summary>FILE_ATTRIBUTE_OFFLINE</summary>
+        Offline = 0x1000,
+
+        /// <summary>FILE_ATTRIBUTE_READONLY</summary>
+        Readonly = 0x01,
+
+        /// <summary>FILE_ATTRIBUTE_REPARSE_POINT</summary>
+        ReparsePoint = 0x400,
+
+        /// <summary>FILE_ATTRIBUTE_SPARSE_FILE</summary>
+        SparseFile = 0x200,
+
+        /// <summary>FILE_ATTRIBUTE_SYSTEM</summary>
+        System = 0x04,
+
+        /// <summary>FILE_ATTRIBUTE_TEMPORARY</summary>
+        Temporary = 0x100,
+
+        /// <summary>FILE_ATTRIBUTE_VIRTUAL</summary>
+        Virtual = 0x10000,
+
+        /// <summary>FILE_FLAG_BACKUP_SEMANTICS</summary>
+        BackupSemantics = 0x02000000,
+
+        /// <summary>FILE_FLAG_DELETE_ON_CLOSE</summary>
+        DeleteOnClose = 0x04000000,
+
+        /// <summary>FILE_FLAG_NO_BUFFERING</summary>
+        NoBuffering = 0x20000000,
+
+        /// <summary>FILE_FLAG_OPEN_NO_RECALL</summary>
+        OpenNoRecall = 0x00100000,
+
+        /// <summary>FILE_FLAG_OPEN_REPARSE_POINT</summary>
+        OpenReparsePoint = 0x00200000,
+
+        /// <summary>FILE_FLAG_OVERLAPPED</summary>
+        Overlapped = 0x40000000,
+
+        /// <summary>FILE_FLAG_POSIX_SEMANTICS</summary>
+        PosixSemantics = 0x0100000,
+
+        /// <summary>FILE_FLAG_RANDOM_ACCESS</summary>
+        RandomAccess = 0x10000000,
+
+        /// <summary>FILE_FLAG_SESSION_AWARE</summary>
+        SessionAware = 0x00800000,
+
+        /// <summary>FILE_FLAG_SEQUENTIAL_SCAN</summary>
+        SequentialScan = 0x08000000,
+
+        /// <summary>FILE_FLAG_WRITE_THROUGH</summary>
+        WriteThrough = 0x80000000
+    }
+
+    [Flags]
+    internal enum FileAccess : uint
+    {
+        /// <summary>FILE_READ_DATA</summary>
+        ReadData = 0x0001,
+
+        /// <summary>FILE_LIST_DIRECTORY</summary>
+        ListDirectory = ReadData,
+
+        /// <summary>FILE_WRITE_DATA</summary>
+        WriteData = 0x0002,
+
+        /// <summary>FILE_ADD_FILE</summary>
+        AddFile = WriteData,
+
+        /// <summary>FILE_APPEND_DATA</summary>
+        AppendData = 0x0004,
+
+        /// <summary>FILE_ADD_SUBDIRECTORY</summary>
+        AddSubdirectory = AppendData,
+
+        /// <summary>FILE_CREATE_PIPE_INSTANCE</summary>
+        CreatePipeInstance = AppendData,
+
+        /// <summary>FILE_READ_EA</summary>
+        ReadEa = 0x0008,
+
+        /// <summary>FILE_WRITE_EA</summary>
+        WriteEa = 0x0010,
+
+        /// <summary>FILE_EXECUTE</summary>
+        Execute = 0x0020,
+
+        /// <summary>FILE_TRAVERSE</summary>
+        Traverse = Execute,
+
+        /// <summary>FILE_DELETE_CHILD</summary>
+        DeleteChild = 0x0040,
+
+        /// <summary>FILE_READ_ATTRIBUTES</summary>
+        ReadAttributes = 0x0080,
+
+        /// <summary>FILE_WRITE_ATTRIBUTES</summary>
+        WriteAttributes = 0x0100,
+
+        /// <summary>GENERIC_READ</summary>
+        GenericRead = 0x80000000,
+
+        /// <summary>GENERIC_WRITE</summary>
+        GenericWrite = 0x40000000,
+
+        /// <summary>GENERIC_EXECUTE</summary>
+        GenericExecute = 0x20000000,
+
+        /// <summary>GENERIC_ALL</summary>
+        GenericAll = 0x10000000
+    }
+
+    [Flags]
+    internal enum FileShare : uint
+    {
+        /// <summary>FILE_SHARE_NONE</summary>
+        None = 0x00,
+
+        /// <summary>FILE_SHARE_READ</summary>
+        Read = 0x01,
+
+        /// <summary>FILE_SHARE_WRITE</summary>
+        Write = 0x02,
+
+        /// <summary>FILE_SHARE_DELETE</summary>
+        Delete = 0x03
+    }
+
+    [LibraryImport("kernel32.dll",
+        EntryPoint = "CreateFileW",
+        SetLastError = true,
+        StringMarshalling = StringMarshalling.Utf16)]
+    internal static partial SafeFileHandle CreateFile(
         [MarshalAs(UnmanagedType.LPTStr)] string filename,
-        [MarshalAs(UnmanagedType.U4)] uint access,
-        [MarshalAs(UnmanagedType.U4)] FileShare share,
-        IntPtr securityAttributes, // optional SECURITY_ATTRIBUTES struct or IntPtr.Zero
-        [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
-        [MarshalAs(UnmanagedType.U4)] uint flagsAndAttributes,
-        IntPtr templateFile);
+        FileAccess access,
+        FileShare share,
+        nint securityAttributes, // optional SECURITY_ATTRIBUTES struct or IntPtr.Zero
+        FileMode creationDisposition,
+        FileAttributes flagsAndAttributes,
+        nint templateFile);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CloseHandle(IntPtr hObject);
-
-    [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    private static extern unsafe uint GetFinalPathNameByHandle(
+    [LibraryImport("kernel32.dll",
+        EntryPoint = "GetFinalPathNameByHandleW",
+        SetLastError = true,
+        StringMarshalling = StringMarshalling.Utf16)]
+    private static unsafe partial uint GetFinalPathNameByHandle(
         IntPtr hFile,
         char* buffer,
         uint bufferLength,
-        uint dwFlags);
+        uint dwFlags = 0);
 }

--- a/TruePath/DiskUtils.cs
+++ b/TruePath/DiskUtils.cs
@@ -1,16 +1,19 @@
+// SPDX-FileCopyrightText: .NET Foundation and Contributors <https://github.com/dotnet/corefx/blob/9c06da6a34fcefa6fb37776ac57b80730e37387c/src/Common/src/System/IO/PathInternal.Windows.cs>
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
+//
+// SPDX-License-Identifier: MIT
+
 using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using Microsoft.Win32.SafeHandles;
-
-// ReSharper disable InconsistentNaming
 
 namespace TruePath;
 
 /// <summary>
 /// Provides interop methods for the libc library.
 /// </summary>
-public static partial class Libc
+internal static partial class Libc
 {
     /// <summary>
     /// Resolves the absolute path of the specified <paramref name="path"/> and stores it in the provided <paramref name="buffer"/>.
@@ -26,6 +29,7 @@ public static partial class Libc
         SetLastError = true,
         StringMarshalling = StringMarshalling.Custom,
         StringMarshallingCustomType = typeof(AnsiStringMarshaller))]
+    // ReSharper disable InconsistentNaming
     internal static partial SafeFileHandle realpath(string path, IntPtr buffer);
 }
 
@@ -38,7 +42,7 @@ public static partial class DiskUtils
     /// <summary>
     /// The maximum path length for Windows.
     /// </summary>
-    public const short WindowsMaxPath = short.MaxValue;
+    private const short WindowsMaxPath = short.MaxValue;
 
     /// <summary>
     /// Gets the real (absolute) path of the specified <paramref name="path"/> depending on the operating system.
@@ -60,7 +64,7 @@ public static partial class DiskUtils
     /// </summary>
     /// <param name="path">The file path to resolve.</param>
     /// <returns>The resolved absolute path, or the original path if resolution fails.</returns>
-    public static string GetPosixRealPath(string path)
+    private static string GetPosixRealPath(string path)
     {
         using var ptr = Libc.realpath(path, IntPtr.Zero);
 
@@ -79,7 +83,7 @@ public static partial class DiskUtils
     /// </summary>
     /// <param name="path">The file path to resolve.</param>
     /// <returns>The resolved absolute path, or the original path if resolution fails.</returns>
-    public static string GetWindowsRealPath(string path)
+    private static string GetWindowsRealPath(string path)
     {
         using var handle = CreateFile(path,
             FileAccess.ReadEa,
@@ -338,7 +342,7 @@ public static partial class DiskUtils
         EntryPoint = "CreateFileW",
         SetLastError = true,
         StringMarshalling = StringMarshalling.Utf16)]
-    internal static partial SafeFileHandle CreateFile(
+    private static partial SafeFileHandle CreateFile(
         [MarshalAs(UnmanagedType.LPTStr)] string filename,
         FileAccess access,
         FileShare share,


### PR DESCRIPTION
### Add method to return canonical path forms

#### Description
This pull request introduces a new `DiskUtils` class designed to generate canonical path forms for both Windows and POSIX platforms. It ensures consistent path formatting across different operating systems, improving the reliability and portability of file path handling in our project.

#### Changes
- **DiskUtils Class**
  - Implemented the `DiskUtils` class with methods to create canonical path forms.
  - Supported platforms: Windows and POSIX.

- **Tests**
  - Added comprehensive tests for the `DiskUtils` class.
  - Verified functionality on both Windows and POSIX platforms to ensure compatibility and correctness.

#### Testing
- All new tests for `DiskUtils` have been executed and passed on both Windows and POSIX environments.

 [Canonical / unique path forms #21 ](https://github.com/ForNeVeR/TruePath/issues/21)

- Closes #21