### PR TITLE
#18 implement behavior to calculate parents from exclusively-relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Incorrect path normalization: last ellipsis (`...`) in a path was treated as a `..` entry.
+
 ### Changed
 - [#18](https://github.com/ForNeVeR/TruePath/issues/18): update to behavior of `.Parent` on relative paths.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   Now, it works for relative paths by either removing the last part or adding `..` as necessary to lead to a parent directory.
 
-  Thanks to @Kataane.
+  Thanks to @Kataane for help on this one.
 
 ## [1.4.0] - 2024-08-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- [#18](https://github.com/ForNeVeR/TruePath/issues/18): update to behavior of `.Parent` on relative paths.
+
+  Now, it works for relative paths by either removing the last part or adding `..` as necessary to lead to a parent directory.
+
+  Thanks to @Kataane.
+
 ## [1.4.0] - 2024-08-12
 ### Changed
 - [#16: Support Windows disk drives in the normalization algorithm](https://github.com/ForNeVeR/TruePath/issues/16).

--- a/README.md
+++ b/README.md
@@ -71,23 +71,28 @@ This is an interface that is implemented by both `LocalPath` and `AbsolutePath`.
 This is a marker type that doesn't offer any advanced functionality over the contained string. It is used to mark paths that include wildcards, for further integration with external libraries, such as [Microsoft.Extensions.FileSystemGlobbing][file-system-globbing.nuget].
 
 ### Path Features
-Aside from the strict types, the following features are supported for the paths:
-- `IPath::Value` returns the normalized path string;
-- `IPath::FileName` returns the last component of the path;
-- `IPath::Parent` returns the parent path item (`null` for the root path or top-level relative path);
-- `IPath<T>` supports operators to join it with `LocalPath` or a `string` (note that in both cases appending an absolute path to path of another kind will take over: the last absolute path in chain will win and destroy all the previous ones; this is the standard behavior of path-combining methods — use `AbsolutePath` in combination with `RelativePath` if you want to avoid this behavior);
-- `IPath::IsPrefixOf` to check path prefixes;
-- `IPath::StartsWith` to check if the current path starts with a specified path;
-- `AbsolutePath::ReadKind` helps to check if a path exists, and if it is, then what kind of path it is (file, directory, or something else);
+Aside from the strict types, the following features are supported for the paths.
+
+- `IPath::Value` returns the normalized path string.
+- `IPath::FileName` returns the last component of the path.
+- `IPath::Parent` returns the parent path item (`null` for the root absolute path).
+
+  Note that it will _always_ return a meaningful parent for a relative path: parent for `.` is `..`, parent for `..` is `../..`.
+
+  This means that generally `.Parent` behaves the same as appending a `..` component to the end of the path would. Also, this allows for an interesting property that `a / b.Parent.Value` is always the same as `(a / b).Parent` and `a / b / ".."` — in cases when this yield no exceptions, at least.
+- `IPath<T>` supports operators to join it with `LocalPath` or a `string` (note that in both cases appending an absolute path to path of another kind will take over: the last absolute path in chain will win and destroy all the previous ones; this is the standard behavior of path-combining methods — use `AbsolutePath` in combination with `RelativePath` if you want to avoid this behavior).
+- `IPath::IsPrefixOf` to check path prefixes.
+- `IPath::StartsWith` to check if the current path starts with a specified path.
+- `AbsolutePath::ReadKind` helps to check if a path exists, and if it is, then what kind of path it is (file, directory, or something else).
 - `AbsolutePath::Canonicalize` to convert the path to the correct case on case-insensitive file systems, resolve symlinks.
-- `LocalPath::IsAbsolute` to check the path kind (since it supports both kinds);
+- `LocalPath::IsAbsolute` to check the path kind (since it supports both kinds).
 - `LocalPath::ResolveToCurrentDirectory`: effectively calculates `currentDirectory / this`. No-op for paths that are already absolute (aside from converting to the `AbsolutePath` type).
-- `AbsolutePath::RelativeTo`, `LocalPath::RelativeTo` to get a relative part between two paths, if possible;
+- `AbsolutePath::RelativeTo`, `LocalPath::RelativeTo` to get a relative part between two paths, if possible.
 - extension methods on `IPath`:
   - `GetExtensionWithDot` and `GetExtensionWithoutDot` to get the file extension with or without the leading dot (note that `GetExtensionWithDot` will behave differently for paths ending with dots and paths without dot at all);
   - `GetFileNameWithoutExtension` to get the file name without the extension (and without the trailing dot, if any)
 
-    (Note how `GetFileNameWithoutExtension()` works nicely together with `GetExtensionWithDot()` to reconstruct the resulting path from their concatenation, however weird the initial name was — no extension, trailing dot, no base name.)
+    (note how `GetFileNameWithoutExtension()` works nicely together with `GetExtensionWithDot()` to reconstruct the resulting path from their concatenation, however weird the initial name was — no extension, trailing dot, no base name).
 
 ### `Temporary`
 

--- a/TruePath.Tests/AbsolutePathTests.cs
+++ b/TruePath.Tests/AbsolutePathTests.cs
@@ -9,6 +9,14 @@ namespace TruePath.Tests;
 public class AbsolutePathTests
 {
     [Fact]
+    public void ConstructionTest()
+    {
+        var root = new AbsolutePath(OperatingSystem.IsWindows() ? @"A:\" : "/");
+        var path = new AbsolutePath($"{root}/...");
+        Assert.Equal($"{root}...", path.Value);
+    }
+
+    [Fact]
     public void ReadKind_NonExistent()
     {
         // Arrange

--- a/TruePath.Tests/AbsolutePathTests.cs
+++ b/TruePath.Tests/AbsolutePathTests.cs
@@ -95,6 +95,18 @@ public class AbsolutePathTests
     }
 
     [Theory]
+    [InlineData("foo", ".")]
+    [InlineData("foo/bar", "foo")]
+    [InlineData("/", null)]
+    public void ParentIsCalculatedCorrectly(string relativePath, string? expectedRelativePath)
+    {
+        var root = new AbsolutePath(OperatingSystem.IsWindows() ? @"A:\" : "/");
+        var parent = root / relativePath;
+        AbsolutePath? expectedPath = expectedRelativePath == null ? null : new(root / expectedRelativePath);
+        Assert.Equal(expectedPath, parent.Parent);
+    }
+
+    [Theory]
     [InlineData("/home/user", "/home/user/documents")]
     [InlineData("/home/usEr", "/home/User/documents")]
     [InlineData("/home/user/documents", "/home/user/documents")]

--- a/TruePath.Tests/LocalPathTests.cs
+++ b/TruePath.Tests/LocalPathTests.cs
@@ -18,10 +18,10 @@ public class LocalPathTests(ITestOutputHelper output)
         Random.Shared.Shuffle(result.ToArray());
         var path = new string(result);
 
-        var a = new LocalPath(path);
+        var localPath = new LocalPath(path);
 
         // Act
-        var parent = a.Parent;
+        var parent = localPath.Parent;
 
         // Assert
         Assert.Null(parent);
@@ -39,10 +39,10 @@ public class LocalPathTests(ITestOutputHelper output)
     public void ExclusivelyRelativePath(string path)
     {
         // Arrange
-        var a = new LocalPath(path);
+        var localPath = new LocalPath(path);
 
         // Act
-        var parent = a.Parent;
+        var parent = localPath.Parent;
 
         // Assert
         Assert.Null(parent);

--- a/TruePath.Tests/LocalPathTests.cs
+++ b/TruePath.Tests/LocalPathTests.cs
@@ -8,6 +8,46 @@ namespace TruePath.Tests;
 
 public class LocalPathTests(ITestOutputHelper output)
 {
+    [Fact]
+    public void AnyExclusivelyRelativePath()
+    {
+        // Arrange
+        var dots = new string(Enumerable.Repeat('.', Random.Shared.Next(1, 21)).ToArray());
+        var backslashes = new string(Enumerable.Repeat(Path.DirectorySeparatorChar, Random.Shared.Next(0, 20)).ToArray());
+        var result = string.Concat(dots.AsSpan(), backslashes.AsSpan()).ToArray();
+        Random.Shared.Shuffle(result.ToArray());
+        var path = new string(result);
+
+        var a = new LocalPath(path);
+
+        // Act
+        var parent = a.Parent;
+
+        // Assert
+        Assert.Null(parent);
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("../..")]
+    [InlineData("../../")]
+    [InlineData("../...")]
+    [InlineData(".../..")]
+    [InlineData("./.")]
+    [InlineData("../../.")]
+    public void ExclusivelyRelativePath(string path)
+    {
+        // Arrange
+        var a = new LocalPath(path);
+
+        // Act
+        var parent = a.Parent;
+
+        // Assert
+        Assert.Null(parent);
+    }
+
     [Theory]
     [InlineData("user", "user/documents")]
     [InlineData("usEr", "User/documents")]
@@ -16,6 +56,8 @@ public class LocalPathTests(ITestOutputHelper output)
     public void IsPrefixOfShouldBeEquivalentToStartsWith(string pathA, string pathB)
     {
         // Arrange
+        var y = PathStrings.Normalize("../..");
+
         var a = new LocalPath(pathA);
         var b = new LocalPath(pathB);
 

--- a/TruePath.Tests/LocalPathTests.cs
+++ b/TruePath.Tests/LocalPathTests.cs
@@ -21,6 +21,18 @@ public class LocalPathTests(ITestOutputHelper output)
     }
 
     [Theory]
+    [InlineData(".", "")]
+    [InlineData("..", "..")]
+    [InlineData("../..", "../..")]
+    [InlineData(".../...", ".../...")]
+    [InlineData(".../..", "")]
+    public void ConstructionTest(string pathString, string expectedValue)
+    {
+        var path = new LocalPath(pathString);
+        Assert.Equal(expectedValue.Replace('/', Path.DirectorySeparatorChar), path.Value);
+    }
+
+    [Theory]
     [InlineData(".", "..")]
     [InlineData("..", "../..")]
     [InlineData("../..", "../../..")]

--- a/TruePath.Tests/LocalPathTests.cs
+++ b/TruePath.Tests/LocalPathTests.cs
@@ -32,6 +32,8 @@ public class LocalPathTests(ITestOutputHelper output)
     [InlineData("b", ".")]
     [InlineData("../b", "..")]
     [InlineData("b/..", "b/../..")]
+    [InlineData("...", ".../..")]
+    [InlineData(".../...", "...")]
     public void RelativePathParent(string path, string? expected)
     {
         // Arrange

--- a/TruePath.Tests/PathStringsTests.cs
+++ b/TruePath.Tests/PathStringsTests.cs
@@ -55,7 +55,11 @@ public class PathStringsTests
     [InlineData("../../foo", "../../foo")]
     [InlineData("../../../foo", "../../../foo")]
     [InlineData("../foo/..", "..")]
-    public void DotFoldersAreTraversed(string input, string expected)
+    [InlineData("...", "...")]
+    [InlineData(".../..", "")]
+    [InlineData(".../...", ".../...")]
+    [InlineData(".../../...", "...")]
+    public void DotFoldersAreTraversedCorrectly(string input, string expected)
     {
         Assert.Equal(NormalizeSeparators(expected), PathStrings.Normalize(input));
     }

--- a/TruePath/IPath.cs
+++ b/TruePath/IPath.cs
@@ -14,8 +14,9 @@ public interface IPath
     string FileName { get; }
 
     /// <summary>
-    /// The parent of this path. Will be <c>null</c> for a rooted absolute path, or relative path pointing to the
-    /// current directory.
+    /// The parent of this path. Will be <c>null</c> for a rooted absolute path. For a relative path, will always
+    /// resolve to its parent directory — by either removing directories from the end of the path, or appending
+    /// <code>..</code> to the end.
     /// </summary>
     IPath? Parent { get; }
 }

--- a/TruePath/LocalPath.cs
+++ b/TruePath/LocalPath.cs
@@ -16,6 +16,8 @@ namespace TruePath;
 /// </summary>
 public readonly struct LocalPath(string value) : IEquatable<LocalPath>, IPath, IPath<LocalPath>
 {
+    private static char Separator => Path.DirectorySeparatorChar;
+
     /// <inheritdoc cref="IPath.Value"/>
     public string Value { get; } = PathStrings.Normalize(value);
 
@@ -29,18 +31,14 @@ public readonly struct LocalPath(string value) : IEquatable<LocalPath>, IPath, I
     public bool IsAbsolute => Path.IsPathRooted(Value);
 
     /// <inheritdoc cref="IPath.Parent"/>
-    public LocalPath? Parent {
+    public LocalPath? Parent
+    {
         get
         {
-            var value = PathStrings.ResolveRelativePaths(Value);
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return null;
-            }
-
+            if (Value == "" || Value == ".." || Value.EndsWith($"{Separator}..")) return this / "..";
             return Path.GetDirectoryName(Value) is { } parent ? new(parent) : null;
         }
-    } 
+    }
 
     /// <inheritdoc cref="IPath.Parent"/>
     IPath? IPath.Parent => Parent;
@@ -89,7 +87,7 @@ public readonly struct LocalPath(string value) : IEquatable<LocalPath>, IPath, I
     public bool IsPrefixOf(LocalPath other)
     {
         if (!(Value.Length <= other.Value.Length && other.Value.StartsWith(Value))) return false;
-        return other.Value.Length == Value.Length || other.Value[Value.Length] == Path.DirectorySeparatorChar;
+        return other.Value.Length == Value.Length || other.Value[Value.Length] == Separator;
     }
 
     /// <summary>

--- a/TruePath/LocalPath.cs
+++ b/TruePath/LocalPath.cs
@@ -29,7 +29,18 @@ public readonly struct LocalPath(string value) : IEquatable<LocalPath>, IPath, I
     public bool IsAbsolute => Path.IsPathRooted(Value);
 
     /// <inheritdoc cref="IPath.Parent"/>
-    public LocalPath? Parent => Path.GetDirectoryName(Value) is { } parent ? new(parent) : null;
+    public LocalPath? Parent {
+        get
+        {
+            var value = PathStrings.ResolveRelativePaths(Value);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return Path.GetDirectoryName(Value) is { } parent ? new(parent) : null;
+        }
+    } 
 
     /// <inheritdoc cref="IPath.Parent"/>
     IPath? IPath.Parent => Parent;

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -75,7 +75,12 @@ public static class PathStrings
             else if (block.Length == 2 && block[0] == '.' && (block[1] == Path.DirectorySeparatorChar || block[1] == Path.AltDirectorySeparatorChar))
                 skip = true;
             // cut if '..' or '../'
-            else if (written != 0 && block.Length is 2 or 3 && block.StartsWith(".."))
+            else if (written != 0
+                && (
+                    block is ".."
+                    || block.SequenceEqual($"..{Path.DirectorySeparatorChar}")
+                    || block.SequenceEqual($"..{Path.AltDirectorySeparatorChar}")
+                ))
             {
                 var alreadyWrittenPart = normalized[..(written - 1)];
                 var jump = alreadyWrittenPart.LastIndexOf(Path.DirectorySeparatorChar);

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -182,4 +182,34 @@ public static class PathStrings
 
         return source[1] == VolumeSeparatorChar && (uint)((source[0] | 0x20) - 'a') <= (uint)('z' - 'a');
     }
+
+    /// <summary>
+    /// Resolves and normalizes relative paths in the given path string by removing redundant path components.
+    /// </summary>
+    /// <param name="source">The path string to process.</param>
+    /// <returns>
+    /// The normalized path string. If the source path contains only directory separators or dots, an empty string is returned. Otherwise, the original path is returned.
+    /// </returns>
+    /// <remarks>
+    /// This method iterates over the characters in the input path string and removes those that are directory separators or dots. If the resulting length of the path is zero, indicating that the path only contained separators or dots, it returns an empty string. Otherwise, it returns the original path unchanged.
+    /// </remarks>
+    internal static string ResolveRelativePaths(string source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return string.Empty;
+        }
+
+        var c = source.Length;
+
+        foreach (var @char in source)
+        {
+            if (@char == Path.DirectorySeparatorChar || @char == '.')
+            {
+                c--;
+            }
+        }
+
+        return c == 0 ? string.Empty : source;
+    }
 }

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -182,34 +182,4 @@ public static class PathStrings
 
         return source[1] == VolumeSeparatorChar && (uint)((source[0] | 0x20) - 'a') <= (uint)('z' - 'a');
     }
-
-    /// <summary>
-    /// Resolves and normalizes relative paths in the given path string by removing redundant path components.
-    /// </summary>
-    /// <param name="source">The path string to process.</param>
-    /// <returns>
-    /// The normalized path string. If the source path contains only directory separators or dots, an empty string is returned. Otherwise, the original path is returned.
-    /// </returns>
-    /// <remarks>
-    /// This method iterates over the characters in the input path string and removes those that are directory separators or dots. If the resulting length of the path is zero, indicating that the path only contained separators or dots, it returns an empty string. Otherwise, it returns the original path unchanged.
-    /// </remarks>
-    internal static string ResolveRelativePaths(string source)
-    {
-        if (string.IsNullOrWhiteSpace(source))
-        {
-            return string.Empty;
-        }
-
-        var c = source.Length;
-
-        foreach (var @char in source)
-        {
-            if (@char == Path.DirectorySeparatorChar || @char == '.')
-            {
-                c--;
-            }
-        }
-
-        return c == 0 ? string.Empty : source;
-    }
 }


### PR DESCRIPTION
Closes #18.

**Pull Request: Define Parent for LocalPath(".") and Relative Paths**

**Problem Description:**
Currently, `new LocalPath(".").Parent` (similarly for paths like `..` or `../..`) is not defined. This creates ambiguity and inconsistency in the behavior of the library.

**Proposed Solution:**
After researching how other libraries handle the parent of paths such as `"."`, `".."`, and `"../.."`, we propose that these should return `null`. This approach aligns with the general expectations and behavior seen in other path-handling libraries.

**Changes Made:**
- Implemented logic to return `null` for the parent of `LocalPath(".")`, `LocalPath("..")`, and other relative paths.
- Added corresponding unit tests to ensure consistent behavior and to prevent regressions in the future. These tests cover the mentioned cases as well as any arbitrary exclusively-relative path.

**Rationale:**
It's important to note that the decision to return `null` is debatable. Here are some examples of how different languages handle these cases:

**Python:**
```python
from pathlib import Path
import os

# Pathlib
path = Path(".")
print(f"For the . parent is {path.parent}")  # For the . parent is .
path = Path("..")
print(f"For the .. parent is {path.parent}")  # For the .. parent is .
path = Path("../..")
print(f"For the ../.. parent is {path.parent}")  # For the ../.. parent is ..

# os.path
path = os.path.dirname(".")
print(f"For the . parent is {path}")  # For the . parent is 
path = os.path.dirname("..")
print(f"For the .. parent is {path}")  # For the .. parent is 
path = os.path.dirname("../..")
print(f"For the ../.. parent is {path}")  # For the ../.. parent is ..
```

**Go:**
```go
package main

import (
    "fmt"
    "path"
)

func main() {
    // .
    // .
    // ..
    parent := path.Dir(".")
    fmt.Println(parent)
    parent2 := path.Dir("..")
    fmt.Println(parent2)
    parent3 := path.Dir("../..")
    fmt.Println(parent3)
}
```

**Java:**
```java
import java.nio.file.Path;
import java.nio.file.Paths;

public class Main {
    public static void main(String[] args) {
        // Parent of current directory: null
        // Parent of parent directory: null
        // Parent directory of the file: ..
        Path currentDir = Paths.get(".");
        Path parentDir = currentDir.getParent();
        System.out.println("Parent of current directory: " + parentDir);

        Path parentPath = Paths.get("..");
        Path parentOfParent = parentPath.getParent();
        System.out.println("Parent of parent directory: " + parentOfParent);

        Path filePath = Paths.get("../..");
        Path fileParent = filePath.getParent();
        System.out.println("Parent directory of the file: " + fileParent);
    }
}
```

**C#:**
```csharp
using System;
using System.IO;

public class Program
{
    public static void Main()
    {
        // All returns the current working folder

        DirectoryInfo dirInfo = new DirectoryInfo(".");
        var parentDir = dirInfo.Parent;
        Console.WriteLine(parentDir);

        DirectoryInfo dirInfo2 = new DirectoryInfo("..");
        var parentDir2 = dirInfo2.Parent;
        Console.WriteLine(parentDir2);

        DirectoryInfo dirInfo3 = new DirectoryInfo("../..");
        var parentDir3 = dirInfo3.Parent;
        Console.WriteLine(parentDir3);
    }
}
```

**Rust:**
```rust
use std::path::Path;

fn main() {
    let path = Path::new(".");
    println!("{:?}", path.parent()); // Some("")

    let path = Path::new("..");
    println!("{:?}", path.parent()); // Some("")

    let path = Path::new("../..");
    println!("{:?}", path.parent()); // Some("..")
}
```

If you look behind the trends, you can see that modern, trendy languages try to reclaim the solved path or treat it fairly with this kind of behaviour.

Bottom line, I definitely can't claim that returning null is a good idea