### PR TITLE
Performance Improvement for `SourceContainsDriveLetter` Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   Thanks to @Kataane.
 - More optimizations for `AbsolutePath`'s `/` operator: it will avoid the unnecessary check for absolute path.
+- [#85: Minor performance improvements for absolute path checking on Windows](https://github.com/ForNeVeR/TruePath/pull/85).
+
+  Thanks to @Kataane.
 
 ### Added
 - `AbsolutePath::Canonicalize` to convert the path to absolute, convert to correct case on case-insensitive file systems, resolve symlinks.

--- a/TruePath.Benchmarks/DriveLetter.cs
+++ b/TruePath.Benchmarks/DriveLetter.cs
@@ -1,0 +1,30 @@
+using System.Buffers;
+
+namespace TruePath.Benchmarks;
+
+public class DriveLetter
+{
+    private static readonly SearchValues<char> DriveLetters = SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+
+    internal const char VolumeSeparatorChar = ':';
+
+    internal static bool UseLatinLetterRange(ReadOnlySpan<char> source)
+    {
+        if (source.Length < 2)
+        {
+            return false;
+        }
+
+        return source[1] == VolumeSeparatorChar && (uint)((source[0] | 0x20) - 'a') <= (uint)('z' - 'a');
+    }
+
+    internal static bool UseSearchValues(ReadOnlySpan<char> source)
+    {
+        if (source.Length < 2) return false;
+
+        var letter = source[0];
+        var colon = source[1];
+
+        return DriveLetters.Contains(letter) && colon == ':';
+    }
+}

--- a/TruePath.Benchmarks/DriveLetter.cs
+++ b/TruePath.Benchmarks/DriveLetter.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
+//
+// SPDX-License-Identifier: MIT
+
 using System.Buffers;
 
 namespace TruePath.Benchmarks;

--- a/TruePath.Benchmarks/DriveLetterBenchmark.cs
+++ b/TruePath.Benchmarks/DriveLetterBenchmark.cs
@@ -1,0 +1,27 @@
+using BenchmarkDotNet.Attributes;
+
+namespace TruePath.Benchmarks;
+
+public class DriveLetterBenchmark
+{
+    public static IEnumerable<string> ValuesForInput =>
+    [
+        "A://", "Z://", "a://", "z://",
+        "K://", "k://", "R://", "r://",
+        "//", "foobar", 
+    ];
+
+    [ParamsSource(nameof(ValuesForInput))] public string Input { get; set; } = null!;
+
+    [Benchmark]
+    public bool UseLatinLetterRange()
+    {
+        return DriveLetter.UseLatinLetterRange(Input);
+    }
+
+    [Benchmark]
+    public bool UseSearchValues()
+    {
+        return DriveLetter.UseSearchValues(Input);
+    }
+}

--- a/TruePath.Benchmarks/DriveLetterBenchmark.cs
+++ b/TruePath.Benchmarks/DriveLetterBenchmark.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
+//
+// SPDX-License-Identifier: MIT
+
 using BenchmarkDotNet.Attributes;
 
 namespace TruePath.Benchmarks;

--- a/TruePath.Benchmarks/Program.cs
+++ b/TruePath.Benchmarks/Program.cs
@@ -79,6 +79,6 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        _ = BenchmarkRunner.Run<NormalizePathBenchmark>();
+        _ = BenchmarkRunner.Run<DriveLetterBenchmark>();
     }
 }

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -10,7 +10,7 @@ namespace TruePath;
 /// <summary>Helper methods to manipulate paths as strings.</summary>
 public static class PathStrings
 {
-    private static readonly SearchValues<char> DriveLetters = SearchValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+    internal const char VolumeSeparatorChar = ':';
 
     /// <summary>
     /// <para>
@@ -175,11 +175,11 @@ public static class PathStrings
     /// </returns>
     private static bool SourceContainsDriveLetter(ReadOnlySpan<char> source)
     {
-        if (source.Length < 2) return false;
+        if (source.Length < 2)
+        {
+            return false;
+        }
 
-        var letter = source[0];
-        var colon = source[1];
-
-        return DriveLetters.Contains(letter) && colon == ':';
+        return source[1] == VolumeSeparatorChar && (uint)((source[0] | 0x20) - 'a') <= (uint)('z' - 'a');
     }
 }


### PR DESCRIPTION
#### Description

This pull request improves the performance of the `SourceContainsDriveLetter` method by optimizing the drive letter check. The new implementation leverages a more efficient method to verify if the source contains a drive letter, resulting in better performance as indicated by the benchmark results.

#### Benchmark Results

The benchmark results show a significant improvement in performance:

| Method              | Input  | Mean     | Error     | StdDev    |
|-------------------- |------- |---------:|----------:|----------:|
| UseLatinLetterRange | //     | 1.276 ns | 0.0195 ns | 0.0182 ns |
| UseSearchValues     | //     | 1.538 ns | 0.0154 ns | 0.0144 ns |
| UseLatinLetterRange | a://   | 1.524 ns | 0.0157 ns | 0.0147 ns |
| UseSearchValues     | a://   | 1.760 ns | 0.0309 ns | 0.0289 ns |
| UseLatinLetterRange | A://   | 1.539 ns | 0.0237 ns | 0.0222 ns |
| UseSearchValues     | A://   | 1.769 ns | 0.0123 ns | 0.0103 ns |
| UseLatinLetterRange | foobar | 1.293 ns | 0.0113 ns | 0.0094 ns |
| UseSearchValues     | foobar | 1.766 ns | 0.0175 ns | 0.0164 ns |
| UseLatinLetterRange | k://   | 1.535 ns | 0.0137 ns | 0.0122 ns |
| UseSearchValues     | k://   | 1.766 ns | 0.0181 ns | 0.0160 ns |
| UseLatinLetterRange | K://   | 1.540 ns | 0.0196 ns | 0.0183 ns |
| UseSearchValues     | K://   | 1.772 ns | 0.0212 ns | 0.0198 ns |
| UseLatinLetterRange | r://   | 1.537 ns | 0.0196 ns | 0.0183 ns |
| UseSearchValues     | r://   | 1.768 ns | 0.0161 ns | 0.0151 ns |
| UseLatinLetterRange | R://   | 1.544 ns | 0.0201 ns | 0.0178 ns |
| UseSearchValues     | R://   | 1.761 ns | 0.0133 ns | 0.0124 ns |
| UseLatinLetterRange | z://   | 1.541 ns | 0.0147 ns | 0.0137 ns |
| UseSearchValues     | z://   | 1.768 ns | 0.0148 ns | 0.0139 ns |
| UseLatinLetterRange | Z://   | 1.539 ns | 0.0228 ns | 0.0202 ns |
| UseSearchValues     | Z://   | 1.766 ns | 0.0215 ns | 0.0201 ns |

On average, the UseLatinLetterRange method is approximately 13-24% faster than the UseSearchValues method across various input scenarios.