### PR TITLE
Add fuzzing of the library

### DIFF
--- a/TruePath.Tests/NormalizatonTests.cs
+++ b/TruePath.Tests/NormalizatonTests.cs
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2024 TruePath contributors <https://github.com/ForNeVeR/TruePath>
+//
+// SPDX-License-Identifier: MIT
+
+namespace TruePath.Tests;
+
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using System.Linq;
+using Xunit.Abstractions;
+
+public class NormalizatonTests
+{
+    private readonly ITestOutputHelper _TestOutputHelper;
+    public NormalizatonTests(ITestOutputHelper testOutputHelper)
+    {
+        _TestOutputHelper = testOutputHelper;
+    }
+
+    [Property(Arbitrary = new[] { typeof(AnyOsPath) })]
+    public void NormalizedPathDoesNotEndWithDirSeparator(List<string> pathParts)
+    {
+        var sourcePath = string.Join("", pathParts);
+
+        // Act
+        var normalizedPath = PathStrings.Normalize(sourcePath);
+
+        _TestOutputHelper.WriteLine($"{sourcePath} => {normalizedPath}");
+        Assert.True(normalizedPath == ""
+            || normalizedPath == Path.DirectorySeparatorChar.ToString()
+            || (normalizedPath.Length == 3 && normalizedPath[1] == ':')
+            || normalizedPath[^1] != Path.DirectorySeparatorChar);
+    }
+
+    [Property(Arbitrary = new[] { typeof(AnyOsPath) })]
+    public void DepthPreserverd(List<string> pathParts)
+    {
+        var sourcePath = string.Join("", pathParts);
+
+        // Act
+        var normalizedPath = PathStrings.Normalize(sourcePath);
+
+        _TestOutputHelper.WriteLine($"{sourcePath} => {normalizedPath}");
+        var collapsedBlock = CollapseSameBlocks(pathParts);
+        var expectedDepth = CountDepth(collapsedBlock);
+        var actualDepth = CountDepth([.. normalizedPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries)]);
+        if (actualDepth != expectedDepth)
+        {
+            _TestOutputHelper.WriteLine($"{string.Join("|", collapsedBlock)}");
+        }
+        Assert.Equal(expectedDepth, actualDepth);
+
+        static int CountDepth(List<string> pathParts)
+        {
+            int depth = 0;
+            foreach (var part in pathParts)
+            {
+                if (part == Path.DirectorySeparatorChar.ToString() || part == Path.AltDirectorySeparatorChar.ToString())
+                {
+                    continue;
+                }
+
+                // Skip home drive which does not affect depth.
+                if (part.Contains(':'))
+                {
+                    continue;
+                }
+
+                if (part == "..")
+                {
+                    if (depth > 0)
+                    {
+                        depth--;
+                    }
+                }
+                else if (part != ".")
+                {
+                    depth++;
+                }
+            }
+            return depth;
+        }
+    }
+
+    private static List<string> CollapseSameBlocks(IEnumerable<string> pathParts)
+    {
+        var result = new List<string>();
+        var lastSeparator = false;
+        var hasHomeDrive = pathParts.Any(part => part.Length > 1 && part[1] == ':');
+        string? homeDrive = null;
+        foreach (var item in pathParts)
+        {
+            if (homeDrive is null)
+            {
+                homeDrive = item;
+            }
+
+            if (item.Length > 1 && item[1] == ':') continue;
+
+            var currentSeparator = item == Path.DirectorySeparatorChar.ToString() || item == Path.AltDirectorySeparatorChar.ToString();
+            if (lastSeparator && currentSeparator)
+            {
+                // Skip consecutive separators
+                continue;
+            }
+
+            if (lastSeparator || currentSeparator)
+            {
+                result.Add(item);
+            }
+            else
+            {
+                if (result.Count > 0)
+                {
+                    result[^1] += item;
+                }
+                else
+                {
+                    result.Add(item);
+                }
+            }
+
+            lastSeparator = currentSeparator;
+
+        }
+
+        if (hasHomeDrive && homeDrive is { })
+        {
+            result.Insert(0, homeDrive);
+        }
+
+        return result;
+    }
+}
+
+internal static class PathGenerators
+{
+    public static Gen<List<string>> LinuxPathItemsGenerator()
+    {
+        var baseDir = Gen.Constant("..");
+        var currentDir = Gen.Constant(".");
+        var threeDots = Gen.Constant("...");
+        var dots = Gen.OneOf([baseDir, currentDir, threeDots]);
+        var textPath = Gen.NonEmptyListOf(Gen.Choose('a', 'z').Or(Gen.Choose('A', 'Z')).Or(Gen.Choose('0', '9'))).Select(l => string.Join("", l.Select(c => (char)c)));
+
+        var directorySeparatorChar = Gen.Constant(Path.DirectorySeparatorChar).Select(c => c.ToString());
+        var altDirectorySeparatorChar = Gen.Constant(Path.AltDirectorySeparatorChar).Select(c => c.ToString());
+        return Gen.NonEmptyListOf(Gen.OneOf([dots, directorySeparatorChar, altDirectorySeparatorChar, textPath]))
+            .Where(l =>
+            {
+                for (int i = 0; i < l.Count - 1; i++)
+                {
+                    // Avoid consecutive dots like "..../.."
+                    if (l[i][0] == '.' && l[i + 1][0] == '.') return false;
+                }
+
+                return true;
+            });
+    }
+
+    public static Gen<List<string>> WindowsPathItemsGenerator()
+    {
+        var driveLetter = Gen.Choose('a', 'z').Or(Gen.Choose('A', 'Z')).Select(c => (char)c + ":");
+        var directorySeparatorChar = Gen.Constant(Path.DirectorySeparatorChar).Select(c => c.ToString());
+        var altDirectorySeparatorChar = Gen.Constant(Path.AltDirectorySeparatorChar).Select(c => c.ToString());
+        var separator = Gen.OneOf([directorySeparatorChar, altDirectorySeparatorChar]);
+        var drivePrefix = Gen.Zip(driveLetter, separator).Select(static t =>
+        {
+            var (driveLetter, separator) = t;
+            return driveLetter + separator;
+        });
+        return Gen.Zip(drivePrefix, LinuxPathItemsGenerator()).Select(static t =>
+        {
+            var (prefix, items) = t;
+            items.Insert(0, prefix);
+            return items;
+        });
+    }
+}
+
+public class AnyOsPath
+{
+    public static Arbitrary<List<string>> Paths()
+    {
+        return Arb.From(Gen.Or(PathGenerators.LinuxPathItemsGenerator(), PathGenerators.WindowsPathItemsGenerator()));
+    }
+}
+
+public class LinuxPath
+{
+    public static Arbitrary<List<string>> Paths()
+    {
+        return Arb.From(PathGenerators.LinuxPathItemsGenerator());
+    }
+}
+
+public class WindowsPath
+{
+    public static Arbitrary<List<string>> Paths()
+    {
+        return Arb.From(PathGenerators.WindowsPathItemsGenerator());
+    }
+}

--- a/TruePath.Tests/PathStringsTests.cs
+++ b/TruePath.Tests/PathStringsTests.cs
@@ -60,6 +60,7 @@ public class PathStringsTests
     [InlineData(".../...", ".../...")]
     [InlineData(".../../...", "...")]
     [InlineData("foo/bar/../file.ext", "foo/file.ext")]
+    [InlineData("N/", "N")]
     public void DotFoldersAreTraversedCorrectly(string input, string expected)
     {
         Assert.Equal(NormalizeSeparators(expected), PathStrings.Normalize(input));
@@ -76,7 +77,6 @@ public class PathStringsTests
     [InlineData("a/../../..", "../..")]
     [InlineData("foo/./bar/../var/./dar/..", "foo/var")]
     [InlineData("foo/.bar", "foo/.bar")]
-    [InlineData("/.", "/")]
     [InlineData("/..", "/..")]
     [InlineData("/../..", "/../..")]
     [InlineData("/../../foo/..", "/../..")]
@@ -91,8 +91,20 @@ public class PathStringsTests
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
 
         var driveLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        driveLetters += driveLetters.ToLowerInvariant();
 
+        foreach (var driveLetter in driveLetters)
+        {
+            var inputPath = $"{driveLetter}:{input}";
+            var expectedPath = $"{driveLetter}:{expected}";
+
+            //Act
+            var actual = PathStrings.Normalize(inputPath);
+
+            // Assert
+            Assert.Equal(NormalizeSeparators(expectedPath), actual);
+        }
+
+        driveLetters += driveLetters.ToLowerInvariant();
         foreach (var driveLetter in driveLetters)
         {
             var inputPath = $"{driveLetter}:{input}";

--- a/TruePath.Tests/TruePath.Tests.csproj
+++ b/TruePath.Tests/TruePath.Tests.csproj
@@ -13,8 +13,9 @@ SPDX-License-Identifier: MIT
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0"/>
-        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="FsCheck.Xunit" Version="3.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -149,7 +149,7 @@ public static class PathStrings
         }
 
         // remove / at the end of path
-        if (written > 2 && normalized[written - 1] == Path.DirectorySeparatorChar)
+        if (written > 1 && normalized[written - 1] == Path.DirectorySeparatorChar)
             written--;
 
         // alloc new path


### PR DESCRIPTION
Create paths from blocks, then validated that library follow proper rules for folding paths.

I generate two kind of paths for now, Windows and Linux.. different is that Windows paths alwas has `X:\` or `X:/` as first entry.
Generate path is list of blocks
- Windows drive prefix (for Windows paths only)
- Directory separator `DirectorySeparatorChar` or `AltDirectorySeparatorChar`.
- `.` current directory marker
- `..` previous directory marker
- Some random combination of letters or digits.

Test apply rules for path normalization and verify that `PathStrings.Normalize` behaves the same