### PR TITLE
Multitarget .NET Standard 2.0 and .NET 8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@ SPDX-License-Identifier: MIT
     </PropertyGroup>
 
     <PropertyGroup Label="Build">
-        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/TruePath.Benchmarks/TruePath.Benchmarks.csproj
+++ b/TruePath.Benchmarks/TruePath.Benchmarks.csproj
@@ -7,6 +7,7 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/TruePath.SystemIo/PathIo.cs
+++ b/TruePath.SystemIo/PathIo.cs
@@ -61,6 +61,7 @@ public static class PathIo
     /// </remarks>
     public static void AppendAllLines(this AbsolutePath path, IEnumerable<string> contents, Encoding encoding) => File.AppendAllLines(path.Value, contents, encoding);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously appends the specified lines to the file, creating the file if it does not already exist.
     /// </summary>
@@ -112,6 +113,7 @@ public static class PathIo
     /// if it doesn't exist, but it doesn't create new directories. Therefore, the value of the path parameter must contain existing directories.
     /// </remarks>
     public static Task AppendAllLinesAsync(this AbsolutePath path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default) => File.AppendAllLinesAsync(path.Value, contents, encoding, cancellationToken);
+#endif
 
     /// <summary>
     /// Appends the specified string to the file, creating the file if it does not already exist.
@@ -161,6 +163,7 @@ public static class PathIo
     /// </remarks>
     public static void AppendAllText(this AbsolutePath path, string? contents, Encoding encoding) => File.AppendAllText(path.Value, contents, encoding);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously appends the specified string to the file, creating the file if it does not already exist.
     /// </summary>
@@ -212,6 +215,7 @@ public static class PathIo
     /// if it doesn't exist, but it doesn't create new directories. Therefore, the value of the path parameter must contain existing directories.
     /// </remarks>
     public static Task AppendAllTextAsync(this AbsolutePath path, string? contents, Encoding encoding, CancellationToken cancellationToken = default) => File.AppendAllTextAsync(path.Value, contents, encoding, cancellationToken);
+#endif
 
     /// <summary>
     /// Creates a <see cref="StreamWriter" /> that appends UTF-8 encoded text to an existing file, or to a new file if the specified file does not exist.
@@ -345,6 +349,7 @@ public static class PathIo
     /// <returns>A <see cref="DateTime"/> structure set to the date and time that the specified file or directory was last written to. This value is expressed in UTC time.</returns>
     public static DateTime GetLastWriteTimeUtc(this AbsolutePath path) => File.GetLastWriteTimeUtc(path.Value);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Gets the <see cref="UnixFileMode"/> of the file on the path.
     /// </summary>
@@ -352,6 +357,7 @@ public static class PathIo
     /// <returns>The <see cref="UnixFileMode"/> of the file on the path.</returns>
     [UnsupportedOSPlatform("windows")]
     public static UnixFileMode GetUnixFileMode(this AbsolutePath path) => File.GetUnixFileMode(path.Value);
+#endif
 
     /// <summary>
     /// Moves a specified file to a new location, providing the option to specify a new file name.
@@ -360,6 +366,7 @@ public static class PathIo
     /// <param name="destFile">The new path and name for the file.</param>
     public static void Move(this AbsolutePath sourceFile, AbsolutePath destFile) => File.Move(sourceFile.Value, destFile.Value);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Moves a specified file to a new location, providing the options to specify a new file name and to replace the destination file if it already exists.
     /// </summary>
@@ -367,6 +374,7 @@ public static class PathIo
     /// <param name="destFile">The new path and name for the file.</param>
     /// <param name="overwrite"><b>true</b> to replace the destination file if it already exists; <b>false</b> otherwise.</param>
     public static void Move(this AbsolutePath sourceFile, AbsolutePath destFile, bool overwrite) => File.Move(sourceFile.Value, destFile.Value, overwrite);
+#endif
 
     /// <summary>
     /// Opens a <see cref="FileStream"/> on the specified path with read/write access with no sharing.
@@ -422,6 +430,7 @@ public static class PathIo
     /// <returns>A byte array containing the contents of the file.</returns>
     public static byte[] ReadAllBytes(this AbsolutePath path) => File.ReadAllBytes(path.Value);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously opens a binary file, reads the contents of the file into a byte array, and then closes the file.
     /// </summary>
@@ -429,6 +438,7 @@ public static class PathIo
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that represents the asynchronous read operation, which wraps the byte array containing the contents of the file.</returns>
     public static Task<byte[]> ReadAllBytesAsync(this AbsolutePath path, CancellationToken cancellationToken = default) => File.ReadAllBytesAsync(path.Value, cancellationToken);
+#endif
 
     /// <summary>
     /// Opens a text file, reads all lines of the file, and then closes the file.
@@ -445,6 +455,7 @@ public static class PathIo
     /// <returns>A string array containing all lines of the file.</returns>
     public static string[] ReadAllLines(this AbsolutePath path, Encoding encoding) => File.ReadAllLines(path.Value, encoding);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously opens a text file, reads all lines of the file, and then closes the file.
     /// </summary>
@@ -461,6 +472,7 @@ public static class PathIo
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that represents the asynchronous read operation, which wraps the string array containing all lines of the file.</returns>
     public static Task<string[]> ReadAllLinesAsync(this AbsolutePath path, Encoding encoding, CancellationToken cancellationToken = default) => File.ReadAllLinesAsync(path.Value, encoding, cancellationToken);
+#endif
 
     /// <summary>
     /// Reads the lines of a file.
@@ -477,6 +489,7 @@ public static class PathIo
     /// <returns>All the lines of the file, or the lines that are the result of a query.</returns>
     public static IEnumerable<string> ReadLines(this AbsolutePath path, Encoding encoding) => File.ReadLines(path.Value, encoding);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously reads the lines of a file.
     /// </summary>
@@ -493,6 +506,7 @@ public static class PathIo
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <returns>The async enumerable that represents all the lines of the file, or the lines that are the result of a query.</returns>
     public static IAsyncEnumerable<string> ReadLinesAsync(this AbsolutePath path, Encoding encoding, CancellationToken cancellationToken = default) => File.ReadLinesAsync(path.Value, encoding, cancellationToken);
+#endif
 
     /// <summary>
     /// Opens a text file, reads all the text in the file, and then closes the file.
@@ -509,6 +523,7 @@ public static class PathIo
     /// <returns>A string containing all the text in the file.</returns>
     public static string ReadAllText(this AbsolutePath path, Encoding encoding) => File.ReadAllText(path.Value, encoding);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously opens a text file, reads all the text in the file, and then closes the file.
     /// </summary>
@@ -525,6 +540,7 @@ public static class PathIo
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that represents the asynchronous read operation, which wraps the string containing all text in the file.</returns>
     public static Task<string> ReadAllTextAsync(this AbsolutePath path, Encoding encoding, CancellationToken cancellationToken = default) => File.ReadAllTextAsync(path.Value, encoding, cancellationToken);
+#endif
 
     /// <summary>
     /// Sets the specified <see cref="FileAttributes"/> of the file on the specified path.
@@ -582,6 +598,7 @@ public static class PathIo
     /// <param name="bytes">The bytes to write to the file.</param>
     public static void WriteAllBytes(this AbsolutePath path, byte[] bytes) => File.WriteAllBytes(path.Value, bytes);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously creates a new file, writes the specified byte array to the file, and then closes the file. If the target file already exists, it is truncated and overwritten.
     /// </summary>
@@ -590,6 +607,7 @@ public static class PathIo
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
     public static Task WriteAllBytesAsync(this AbsolutePath path, byte[] bytes, CancellationToken cancellationToken = default) => File.WriteAllBytesAsync(path.Value, bytes, cancellationToken);
+#endif
 
     /// <summary>
     /// Creates a new file, writes a collection of strings to the file, and then closes the file.
@@ -621,6 +639,7 @@ public static class PathIo
     /// <param name="encoding">An <see cref="Encoding"/> object that represents the character encoding applied to the string array.</param>
     public static void WriteAllLines(this AbsolutePath path, string[] contents, Encoding encoding) => File.WriteAllLines(path.Value, contents, encoding);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously creates a new file, writes the specified lines to the file, and then closes the file.
     /// </summary>
@@ -639,6 +658,7 @@ public static class PathIo
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
     public static Task WriteAllLinesAsync(this AbsolutePath path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default) => File.WriteAllLinesAsync(path.Value, contents, encoding, cancellationToken);
+#endif
 
     /// <summary>
     /// Creates a new file, writes the specified string to the file, and then closes the file. If the target file already exists, it is truncated and overwritten.
@@ -655,6 +675,7 @@ public static class PathIo
     /// <param name="encoding">The character encoding to use.</param>
     public static void WriteAllText(this AbsolutePath path, string? contents, Encoding encoding) => File.WriteAllText(path.Value, contents, encoding);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asynchronously creates a new file, writes the specified string to the file, and then closes the file. If the target file already exists, it is truncated and overwritten.
     /// </summary>
@@ -673,6 +694,7 @@ public static class PathIo
     /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
     public static Task WriteAllTextAsync(this AbsolutePath path, string? contents, Encoding encoding, CancellationToken cancellationToken = default) => File.WriteAllTextAsync(path.Value, contents, encoding, cancellationToken);
+#endif
 
     /// <summary>
     /// Returns the names of files (including their paths) that match the specified search pattern in the specified directory.
@@ -689,6 +711,7 @@ public static class PathIo
     /// <returns>An array of the full names (including paths) for the files in the specified directory that match the specified search pattern.</returns>
     public static string[] GetFiles(this AbsolutePath path, string searchPattern) => Directory.GetFiles(path.Value, searchPattern);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Returns the names of files (including their paths) that match the specified search pattern and enumeration options in the specified directory.
     /// </summary>
@@ -697,6 +720,7 @@ public static class PathIo
     /// <param name="enumerationOptions">An object that contains the search options to use.</param>
     /// <returns>An array of the full names (including paths) for the files in the specified directory that match the specified search pattern and enumeration options.</returns>
     public static string[] GetFiles(this AbsolutePath path, string searchPattern, EnumerationOptions enumerationOptions) => Directory.GetFiles(path.Value, searchPattern, enumerationOptions);
+#endif
 
     /// <summary>
     /// Returns the names of files (including their paths) that match the specified search pattern in the specified directory, using a value to determine whether to search subdirectories.
@@ -722,6 +746,7 @@ public static class PathIo
     /// <returns>An array of the full names (including paths) for the subdirectories in the specified directory that match the specified search pattern.</returns>
     public static string[] GetDirectories(this AbsolutePath path, string searchPattern) => Directory.GetDirectories(path.Value, searchPattern);
 
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Returns the names of subdirectories (including their paths) that match the specified search pattern and enumeration options in the specified directory.
     /// </summary>
@@ -730,6 +755,7 @@ public static class PathIo
     /// <param name="enumerationOptions">An object that contains the search options to use.</param>
     /// <returns>An array of the full names (including paths) for the subdirectories in the specified directory that match the specified search pattern and enumeration options.</returns>
     public static string[] GetDirectories(this AbsolutePath path, string searchPattern, EnumerationOptions enumerationOptions) => Directory.GetDirectories(path.Value, searchPattern, enumerationOptions);
+#endif
 
     /// <summary>
     /// Returns the names of subdirectories (including their paths) that match the specified search pattern in the specified directory, using a value to determine whether to search subdirectories.

--- a/TruePath.SystemIo/TruePath.SystemIo.csproj
+++ b/TruePath.SystemIo/TruePath.SystemIo.csproj
@@ -7,6 +7,7 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <PackageDescription>Adapters to use System.IO.File and System.IO.Directory APIs together with TruePath.</PackageDescription>
         <RootNamespace>TruePath.SystemIO</RootNamespace>

--- a/TruePath.Tests/TruePath.Tests.csproj
+++ b/TruePath.Tests/TruePath.Tests.csproj
@@ -7,6 +7,7 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/TruePath/AbsolutePath.cs
+++ b/TruePath/AbsolutePath.cs
@@ -105,8 +105,11 @@ public readonly struct AbsolutePath : IEquatable<AbsolutePath>, IComparable<Abso
     /// </summary>
     /// <param name="basePath">The base path from which to calculate the relative path.</param>
     /// <returns>The relative path from the base path to this path.</returns>
+#if NET8_0_OR_GREATER
     public LocalPath RelativeTo(AbsolutePath basePath) => new(Path.GetRelativePath(basePath.Value, Value));
-
+#else
+    public LocalPath RelativeTo(AbsolutePath basePath) => new(PathEx.GetRelativePath(basePath.Value, Value));
+#endif
     /// <summary>Corrects the file name case on case-insensitive file systems, resolves symlinks.</summary>
     public AbsolutePath Canonicalize() => new(DiskUtils.GetRealPath(Value));
 

--- a/TruePath/AbsolutePath.cs
+++ b/TruePath/AbsolutePath.cs
@@ -83,7 +83,11 @@ public readonly struct AbsolutePath : IEquatable<AbsolutePath>, IComparable<Abso
     /// <inheritdoc cref="IPath{TPath}.StartsWith(TPath)"/>
     public bool StartsWith(AbsolutePath other) => Value.StartsWith(other.Value);
 
-    /// <inheritdoc cref="AbsolutePath(string)"/>
+    /// <summary>
+    /// Creates a new path instance of type <see cref="AbsolutePath" /> from the specified string value.
+    /// </summary>
+    /// <param name="value">The string representation of the path to create.</param>
+    /// <returns>A new instance of <see cref="AbsolutePath" /> representing the specified path.</returns>
     public static AbsolutePath Create(string value) => new(value);
 
     /// <inheritdoc cref="IPath{TPath}.IsPrefixOf(TPath)"/>
@@ -113,6 +117,7 @@ public readonly struct AbsolutePath : IEquatable<AbsolutePath>, IComparable<Abso
     /// <summary>Corrects the file name case on case-insensitive file systems, resolves symlinks.</summary>
     public AbsolutePath Canonicalize() => new(DiskUtils.GetRealPath(Value));
 
+    /// <summary>Appends another path to this one.</summary>
     /// <remarks>
     /// Note that in case path <paramref name="b"/> is <b>absolute</b>, it will completely take over and the
     /// <paramref name="basePath"/> will be ignored.
@@ -120,6 +125,7 @@ public readonly struct AbsolutePath : IEquatable<AbsolutePath>, IComparable<Abso
     public static AbsolutePath operator /(AbsolutePath basePath, LocalPath b) =>
         new(Path.Combine(basePath.Value, b.Value), false);
 
+    /// <summary>Appends another path to this one.</summary>
     /// <remarks>
     /// Note that in case path <paramref name="b"/> is <b>absolute</b>, it will completely take over and the
     /// <paramref name="basePath"/> will be ignored.

--- a/TruePath/DiskUtils.cs
+++ b/TruePath/DiskUtils.cs
@@ -166,19 +166,19 @@ internal static class DiskUtils
                 return null;
         }
 
-        if (string.IsNullOrWhiteSpace(realPath))
+        if (string.IsNullOrWhiteSpace(realPath) || realPath is null)
         {
             return null;
         }
 
         //The string that is returned by this function uses the \?\ syntax
-        if (realPath.Length >= 8 && realPath.AsSpan().StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase))
+        if (realPath.Length >= 8 && realPath.AsSpan().StartsWith(@"\\?\UNC\".AsSpan(), StringComparison.OrdinalIgnoreCase))
         {
             // network path, replace `\\?\UNC\` with `\\`
-            realPath = string.Concat("\\", realPath.AsSpan(7));
+            realPath = string.Concat("\\", realPath[7..]);
         }
 
-        if (realPath.Length >= 4 && realPath.AsSpan().StartsWith(@"\\?\", StringComparison.OrdinalIgnoreCase))
+        if (realPath.Length >= 4 && realPath.AsSpan().StartsWith(@"\\?\".AsSpan(), StringComparison.OrdinalIgnoreCase))
         {
             // local path, remove `\\?\`
             realPath = realPath.AsSpan(4).ToString();

--- a/TruePath/Extensions/DirectoryEx.cs
+++ b/TruePath/Extensions/DirectoryEx.cs
@@ -1,0 +1,29 @@
+#if !NET8_0_OR_GREATER
+// ReSharper disable once CheckNamespace
+namespace System.IO;
+
+/// <summary>
+/// Class that contains custom implementations methods of <see cref="Directory"/> class presented in .NET 8 but missing in .NET Standard 2.0.
+/// </summary>
+public static class DirectoryEx
+{
+    public static DirectoryInfo CreateTempSubdirectory(string? prefix = null)
+    {
+        var tempPath = Path.GetTempPath();
+        var directoryName = BuildDirectoryName(prefix);
+        var fullPath = Path.Combine(tempPath, directoryName);
+
+        return Directory.CreateDirectory(fullPath);
+    }
+
+    private static string BuildDirectoryName(string? prefix)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd_HHmmss");
+        var randomPart = Path.GetRandomFileName().Replace(".", "");
+
+        return prefix != null
+            ? $"{prefix}_{timestamp}_{randomPart}"
+            : $"tmp_{timestamp}_{randomPart}";
+    }
+}
+#endif

--- a/TruePath/Extensions/DirectoryEx.cs
+++ b/TruePath/Extensions/DirectoryEx.cs
@@ -9,7 +9,7 @@ namespace System.IO;
 /// <summary>
 /// Class that contains custom implementations methods of <see cref="Directory"/> class presented in .NET 8 but missing in .NET Standard 2.0.
 /// </summary>
-public static class DirectoryEx
+internal static class DirectoryEx
 {
     public static DirectoryInfo CreateTempSubdirectory(string? prefix = null)
     {

--- a/TruePath/Extensions/DirectoryEx.cs
+++ b/TruePath/Extensions/DirectoryEx.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 TruePath contributors <https://github.com/ForNeVeR/TruePath>
+//
+// SPDX-License-Identifier: MIT
+
 #if !NET8_0_OR_GREATER
 // ReSharper disable once CheckNamespace
 namespace System.IO;

--- a/TruePath/Extensions/PathEx.cs
+++ b/TruePath/Extensions/PathEx.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 TruePath contributors <https://github.com/ForNeVeR/TruePath>
+//
+// SPDX-License-Identifier: MIT
+
 #if !NET8_0_OR_GREATER
 // ReSharper disable once CheckNamespace
 namespace System.IO;

--- a/TruePath/Extensions/PathEx.cs
+++ b/TruePath/Extensions/PathEx.cs
@@ -1,0 +1,27 @@
+#if !NET8_0_OR_GREATER
+// ReSharper disable once CheckNamespace
+namespace System.IO;
+
+/// <summary>
+/// Class that contains custom implementations methods of <see cref="Path"/> class presented in .NET 8 but missing in .NET Standard 2.0.
+/// </summary>
+internal static class PathEx
+{
+    public static string GetRelativePath(string relativeTo, string path)
+    {
+        if (string.IsNullOrEmpty(relativeTo)) throw new ArgumentNullException(nameof(relativeTo));
+        if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+
+        var relativeUri = new Uri(Path.GetFullPath(relativeTo) + Path.DirectorySeparatorChar);
+        var pathUri = new Uri(Path.GetFullPath(path));
+
+        if (relativeUri.Scheme != pathUri.Scheme)
+            return path;
+
+        var relativePathUri = relativeUri.MakeRelativeUri(pathUri);
+        var relativePath = Uri.UnescapeDataString(relativePathUri.ToString());
+
+        return relativePath.Replace('/', Path.DirectorySeparatorChar);
+    }
+}
+#endif

--- a/TruePath/IPath.cs
+++ b/TruePath/IPath.cs
@@ -28,13 +28,13 @@ public interface IPath<TPath> where TPath : IPath<TPath>
 #if NET8_0_OR_GREATER
     /// <summary>Appends another path to this one.</summary>
     /// <remarks>
-    /// Note that in case path <paramref name="appended" /> is <b>absolute</b>, it will completely take over and the
-    /// <paramref name="basePath" /> will be ignored.
+    /// Note that in case path <paramref name="appended"/> is <b>absolute</b>, it will completely take over and the
+    /// <paramref name="basePath"/> will be ignored.
     /// </remarks>
-    public static abstract TPath operator /(TPath basePath, LocalPath appended);
+    static abstract TPath operator /(TPath basePath, LocalPath appended);
 
-    /// <inheritdoc cref="!:op_Division(TPath,LocalPath)" />
-    public static abstract TPath operator /(TPath basePath, string appended);
+    /// <inheritdoc cref="op_Division(TPath,LocalPath)"/>
+    static abstract TPath operator /(TPath basePath, string appended);
 #endif
 
     /// <remarks>

--- a/TruePath/IPath.cs
+++ b/TruePath/IPath.cs
@@ -25,15 +25,17 @@ public interface IPath
 /// <typeparam name="TPath">The type of this path.</typeparam>
 public interface IPath<TPath> where TPath : IPath<TPath>
 {
+#if NET8_0_OR_GREATER
     /// <summary>Appends another path to this one.</summary>
     /// <remarks>
-    /// Note that in case path <paramref name="appended"/> is <b>absolute</b>, it will completely take over and the
-    /// <paramref name="basePath"/> will be ignored.
+    /// Note that in case path <paramref name="appended" /> is <b>absolute</b>, it will completely take over and the
+    /// <paramref name="basePath" /> will be ignored.
     /// </remarks>
-    static abstract TPath operator /(TPath basePath, LocalPath appended);
+    public static abstract TPath operator /(TPath basePath, LocalPath appended);
 
-    /// <inheritdoc cref="op_Division(TPath,LocalPath)"/>
-    static abstract TPath operator /(TPath basePath, string appended);
+    /// <inheritdoc cref="!:op_Division(TPath,LocalPath)" />
+    public static abstract TPath operator /(TPath basePath, string appended);
+#endif
 
     /// <remarks>
     /// Checks for a non-strict prefix: if the paths are equal, then they are still considered prefixes of each other.

--- a/TruePath/IPath.cs
+++ b/TruePath/IPath.cs
@@ -52,10 +52,10 @@ public interface IPath<TPath> where TPath : IPath<TPath>
 
 #if NET8_0_OR_GREATER
     /// <summary>
-    /// Creates a new path instance of type <typeparamref name="TPath" /> from the specified string value.
+    /// Creates a new path instance of type <typeparamref name="TPath"/> from the specified string value.
     /// </summary>
     /// <param name="value">The string representation of the path to create.</param>
-    /// <returns>A new instance of <typeparamref name="TPath" /> representing the specified path.</returns>
-    public static abstract TPath Create(string value);
+    /// <returns>A new instance of <typeparamref name="TPath"/> representing the specified path.</returns>
+    static abstract TPath Create(string value);
 #endif
 }

--- a/TruePath/IPath.cs
+++ b/TruePath/IPath.cs
@@ -48,10 +48,12 @@ public interface IPath<TPath> where TPath : IPath<TPath>
     /// <remarks>Note that currently this comparison is case-sensitive.</remarks>
     bool StartsWith(TPath other);
 
+#if NET8_0_OR_GREATER
     /// <summary>
-    /// Creates a new path instance of type <typeparamref name="TPath"/> from the specified string value.
+    /// Creates a new path instance of type <typeparamref name="TPath" /> from the specified string value.
     /// </summary>
     /// <param name="value">The string representation of the path to create.</param>
-    /// <returns>A new instance of <typeparamref name="TPath"/> representing the specified path.</returns>
-    static abstract TPath Create(string value);
+    /// <returns>A new instance of <typeparamref name="TPath" /> representing the specified path.</returns>
+    public static abstract TPath Create(string value);
+#endif
 }

--- a/TruePath/Kernel32.cs
+++ b/TruePath/Kernel32.cs
@@ -9,7 +9,7 @@ using Microsoft.Win32.SafeHandles;
 namespace TruePath;
 
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-internal static partial class Kernel32
+internal static class Kernel32
 {
     /// <summary>
     /// Retrieves the final path for the specified file handle.
@@ -19,11 +19,11 @@ internal static partial class Kernel32
     /// <param name="bufferLength">The size of the buffer, in characters.</param>
     /// <param name="dwFlags">The flags to specify the path format.</param>
     /// <returns>The length of the string copied to the buffer.</returns>
-    [LibraryImport("kernel32.dll",
+    [DllImport("kernel32.dll",
         EntryPoint = "GetFinalPathNameByHandleW",
         SetLastError = true,
-        StringMarshalling = StringMarshalling.Utf16)]
-    internal static unsafe partial uint GetFinalPathNameByHandle(
+        CharSet = CharSet.Unicode)]
+    internal static extern unsafe uint GetFinalPathNameByHandle(
         IntPtr hFile,
         char* buffer,
         uint bufferLength,
@@ -202,11 +202,11 @@ internal static partial class Kernel32
     /// <param name="flagsAndAttributes">The file or device attributes and flags.</param>
     /// <param name="templateFile">A valid handle to a template file, or <c>IntPtr.Zero</c>.</param>
     /// <returns>A <see cref="SafeFileHandle"/> for the opened file or device.</returns>
-    [LibraryImport("kernel32.dll",
+    [DllImport("kernel32.dll",
         EntryPoint = "CreateFileW",
         SetLastError = true,
-        StringMarshalling = StringMarshalling.Utf16)]
-    internal static partial SafeFileHandle CreateFile(
+        CharSet = CharSet.Unicode)]
+    internal static extern SafeFileHandle CreateFile(
         [MarshalAs(UnmanagedType.LPTStr)] string filename,
         FileAccess access,
         FileShare share,
@@ -248,9 +248,9 @@ internal static partial class Kernel32
     /// <remarks>
     /// For more information, see <see href="https://learn.microsoft.com/windows-hardware/drivers/ifs/fsctl-get-reparse-point"/>.
     /// </remarks>
-    [LibraryImport("kernel32.dll", EntryPoint = "DeviceIoControl", SetLastError = true)]
+    [DllImport("kernel32.dll", EntryPoint = "DeviceIoControl", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    internal static unsafe partial bool DeviceIoControl(
+    internal static extern unsafe bool DeviceIoControl(
         SafeHandle hDevice,
         uint dwIoControlCode,
         void* lpInBuffer,

--- a/TruePath/Libc.cs
+++ b/TruePath/Libc.cs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
 using Microsoft.Win32.SafeHandles;
 
 namespace TruePath;
@@ -11,7 +10,7 @@ namespace TruePath;
 /// <summary>
 /// Provides interop methods for the libc library.
 /// </summary>
-internal static partial class Libc
+internal static class Libc
 {
     /// <summary>
     /// Resolves the absolute path of the specified <paramref name="path"/> and stores it in the provided <paramref name="buffer"/>.
@@ -22,10 +21,9 @@ internal static partial class Libc
     /// <remarks>
     /// This method is an interop call to the 'realpath' function in the libc library. The <paramref name="buffer"/> should be allocated with enough space to hold the resolved path.
     /// </remarks>
-    [LibraryImport("libc",
+    [DllImport("libc",
         EntryPoint = "realpath",
         SetLastError = true,
-        StringMarshalling = StringMarshalling.Custom,
-        StringMarshallingCustomType = typeof(AnsiStringMarshaller))]
-    internal static partial SafeFileHandle RealPath(string path, IntPtr buffer);
+        CharSet = CharSet.Ansi)]
+    internal static extern SafeFileHandle RealPath(string path, IntPtr buffer);
 }

--- a/TruePath/LocalPath.cs
+++ b/TruePath/LocalPath.cs
@@ -129,8 +129,11 @@ public readonly struct LocalPath(string value) : IEquatable<LocalPath>, ICompara
     /// </summary>
     /// <param name="basePath">The base path from which to calculate the relative path.</param>
     /// <returns>The relative path from the base path to this path.</returns>
+#if NET8_0_OR_GREATER
     public LocalPath RelativeTo(LocalPath basePath) => new(Path.GetRelativePath(basePath.Value, Value));
-
+#else
+    public LocalPath RelativeTo(LocalPath basePath) => new(PathEx.GetRelativePath(basePath.Value, Value));
+#endif
     /// <summary>Appends another path to this one.</summary>
     /// <remarks>
     /// Note that in case path <paramref name="b"/> is <b>absolute</b>, it will completely take over and the

--- a/TruePath/PathExtensions.cs
+++ b/TruePath/PathExtensions.cs
@@ -21,7 +21,7 @@ public static class PathExtensions
     ///     and potentially reconstruct the file name from its part without the extension and the "extension with dot".
     /// </remarks>
     public static string GetExtensionWithDot(this IPath path) =>
-        path.FileName.EndsWith('.') ? "." : Path.GetExtension(path.FileName);
+        path.FileName.EndsWith(".") ? "." : Path.GetExtension(path.FileName);
 
     /// <summary>
     /// <para>Gets the extension of the file name of the <paramref name="path"/> without the dot character.</para>
@@ -51,16 +51,28 @@ public static class PathExtensions
         Path.GetFileNameWithoutExtension(path.FileName);
 
     /// <summary>
-    /// Returns a new path of the same type <typeparamref name="TPath"/> with the extension of its file name component changed,
+    /// Returns a new path of type <see cref="AbsolutePath"/> with the extension of its file name component changed,
     /// or with a new extension-like component if the original file name was empty.
     /// </summary>
-    /// <typeparam name="TPath">The type of the path, which must implement <see cref="IPath{TPath}"/>.</typeparam>
     /// <param name="path">The original path.</param>
     /// <param name="extension">The new extension to apply.</param>
     /// <returns>
-    /// A new path of type <typeparamref name="TPath"/> with the modified file name component.
+    /// A new path of type <see cref="AbsolutePath"/> with the modified file name component.
     /// The original <paramref name="path"/> object is not modified.
     /// </returns>
-    public static TPath WithExtension<TPath>(this TPath path, string? extension) where TPath : IPath<TPath> =>
-        TPath.Create(Path.ChangeExtension(((IPath)path).Value, extension));
+    public static AbsolutePath WithExtension(this AbsolutePath path, string? extension) =>
+        AbsolutePath.Create(Path.ChangeExtension(path.Value, extension));
+
+    /// <summary>
+    /// Returns a new path of type <see cref="LocalPath"/> with the extension of its file name component changed,
+    /// or with a new extension-like component if the original file name was empty.
+    /// </summary>
+    /// <param name="path">The original path.</param>
+    /// <param name="extension">The new extension to apply.</param>
+    /// <returns>
+    /// A new path of type <see cref="LocalPath"/> with the modified file name component.
+    /// The original <paramref name="path"/> object is not modified.
+    /// </returns>
+    public static LocalPath WithExtension(this LocalPath path, string? extension) =>
+        LocalPath.Create(Path.ChangeExtension(path.Value, extension));
 }

--- a/TruePath/PathExtensions.cs
+++ b/TruePath/PathExtensions.cs
@@ -50,6 +50,21 @@ public static class PathExtensions
     public static string GetFilenameWithoutExtension(this IPath path) =>
         Path.GetFileNameWithoutExtension(path.FileName);
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Returns a new path of the same type <typeparamref name="TPath"/> with the extension of its file name component changed,
+    /// or with a new extension-like component if the original file name was empty.
+    /// </summary>
+    /// <typeparam name="TPath">The type of the path, which must implement <see cref="IPath{TPath}"/>.</typeparam>
+    /// <param name="path">The original path.</param>
+    /// <param name="extension">The new extension to apply.</param>
+    /// <returns>
+    /// A new path of type <typeparamref name="TPath"/> with the modified file name component.
+    /// The original <paramref name="path"/> object is not modified.
+    /// </returns>
+    public static TPath WithExtension<TPath>(this TPath path, string? extension) where TPath : IPath<TPath> =>
+        TPath.Create(Path.ChangeExtension(((IPath)path).Value, extension));
+#else
     /// <summary>
     /// Returns a new path of type <see cref="AbsolutePath"/> with the extension of its file name component changed,
     /// or with a new extension-like component if the original file name was empty.
@@ -75,4 +90,5 @@ public static class PathExtensions
     /// </returns>
     public static LocalPath WithExtension(this LocalPath path, string? extension) =>
         LocalPath.Create(Path.ChangeExtension(path.Value, extension));
+#endif
 }

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -80,8 +80,8 @@ public static class PathStrings
             else if (written != 0
                 && (
                     block is ".."
-                    || block.SequenceEqual($"..{Path.DirectorySeparatorChar}")
-                    || block.SequenceEqual($"..{Path.AltDirectorySeparatorChar}")
+                    || block.SequenceEqual($"..{Path.DirectorySeparatorChar}".AsSpan())
+                    || block.SequenceEqual($"..{Path.AltDirectorySeparatorChar}".AsSpan())
                 ))
             {
                 var alreadyWrittenPart = normalized[..(written - 1)];
@@ -105,7 +105,7 @@ public static class PathStrings
                 else if (jump != -1)
                 {
                     written = last ? jump : jump + 1;
-                    buffer = normalized.Slice(written);
+                    buffer = normalized[written..];
                     skip = true;
                 }
                 else
@@ -142,7 +142,7 @@ public static class PathStrings
 
         if (written == 0 && containsDriveLetter)
         {
-            return new string(path.AsSpan(0, 2));
+            return path[..2];
         }
 
         if (written == 0)
@@ -159,12 +159,12 @@ public static class PathStrings
 
         if (containsDriveLetter)
         {
-            var normalizedRef = new ReadOnlySpan<char>(normalized.ToArray(), 0, written);
-            result = string.Concat(path.AsSpan(0, 2), normalizedRef.Slice(0, written));
+            var normalizedArr = normalized[..written].ToArray();
+            result = new string(path.AsSpan(0, 2).ToArray()) + new string(normalizedArr);
         }
         else
         {
-            result = new string(normalized.Slice(0, written));
+            result = new string(normalized[..written].ToArray());
         }
 
         normalized.Slice(0, written);

--- a/TruePath/PathStrings.cs
+++ b/TruePath/PathStrings.cs
@@ -39,7 +39,9 @@ public static class PathStrings
     ///     Note that this operation will never perform any file IO, and is purely string manipulation.
     /// </para>
     /// </summary>
+#if NET8_0_OR_GREATER
     [SkipLocalsInit] // is necessary to prevent the CLR from filling stackalloc with zeros.
+#endif
     public static string Normalize(string path)
     {
         bool containsDriveLetter = SourceContainsDriveLetter(path.AsSpan());

--- a/TruePath/Temporary.cs
+++ b/TruePath/Temporary.cs
@@ -37,7 +37,11 @@ public static class Temporary
     /// <returns>An AbsolutePath representing newly created temporary folder</returns>
     public static AbsolutePath CreateTempFolder(string? prefix = null)
     {
+#if NET8_0_OR_GREATER
         var tempDirectoryInfo = Directory.CreateTempSubdirectory(prefix);
+#else
+        var tempDirectoryInfo = DirectoryEx.CreateTempSubdirectory(prefix);
+#endif
         return AbsolutePath.CurrentWorkingDirectory / tempDirectoryInfo.FullName;
     }
 }

--- a/TruePath/TruePath.csproj
+++ b/TruePath/TruePath.csproj
@@ -7,6 +7,7 @@ SPDX-License-Identifier: MIT
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <PackageDescription>File path abstraction library for .NET.</PackageDescription>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -14,5 +15,9 @@ SPDX-License-Identifier: MIT
 
     <ItemGroup>
         <InternalsVisibleTo Include="TruePath.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.7" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
As TruePath is going to be used in a .NET Standard 2.0 targeted projects, it is necessary to introduce a proper level of support for it. While some features and API are impossible to implement for .NET Standard 2.0, and we don't want to lose them in .NET 8+ projects, I've decided to make TruePath to target both .NET and .NET Standard.

## Important changes
- `TruePath` package gets a new dependency - `Microsoft.Bcl.Memory`. It is necessary to support the C# property range expression feature for System.Range type in .NET Standard 2.0.
- There might be some performance degradation, as not all Span-based features are available in .NET Standard 2.0, and it's tricky to support 2 separate implementations.
- Source-generators-based `[LibraryImport]` attributes got replaced with more portable and well-supported `[DllImport]` in places where native interop is used
- Test project only compiles under .NET 8 target, which means .NET Standard 2.0-specific changes are not presented in tests. This is something that should be better done from the testing side in the future. 

I expect no breaking changes from my work for .NET 8 users, as the public API remains unchanged for the .NET 8 version of the library, thanks to the C# syntax and preprocessor directives.

The only thing I'm worried about is `[DllImport]` usage. According to tests, everything works fine, but careful review is needed there to check that it will work the same way as before.